### PR TITLE
add HUAWEI FreeBuds Pro 2

### DIFF
--- a/src/openfreebuds/device/huawei/__init__.py
+++ b/src/openfreebuds/device/huawei/__init__.py
@@ -5,4 +5,5 @@ devices = {
     "HUAWEI FreeBuds 5i": FreeBuds4iDevice,
     "HONOR Earbuds 2 Lite": FreeBuds4iDevice,
     "HUAWEI FreeLace Pro": FreeLaceProDevice,
+    "HUAWEI FreeBuds Pro 2": FreeBuds4iDevice,
 }


### PR DESCRIPTION
Для HUAWEI FreeBuds Pro 2 можно использовать профиль 4i. Если правильно понял структуру твоего проекта, этого должно быть достаточно.