### PR TITLE
Add additional uninstall registry keys in the installer

### DIFF
--- a/openfreebuds.nsi
+++ b/openfreebuds.nsi
@@ -2,6 +2,7 @@
 !include "x64.nsh"
 
 !define APP_NAME "OpenFreebuds"
+!define APP_VERSION "0.12.3"
 !define APP_DEVELOPER "MelianMiko"
 !define APP_BUILD_NAME "openfreebuds"
 !define APP_EXE "openfreebuds.exe"
@@ -59,9 +60,17 @@ Section "Dummy Section" SecDummy
 	;Store installation folder
 	WriteRegStr HKCU "Software\${APP_DEVELOPER} ${APP_NAME}" "" $INSTDIR
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}_APP" \
+			"DisplayIcon" "$INSTDIR\openfreebuds.exe"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}_APP" \
 			"DisplayName" "OpenFreebuds"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}_APP" \
+			"DisplayVersion" "${APP_VERSION}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}_APP" \ 
+			"QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}_APP" \
 			"UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}_APP" \
+			"Publisher" "${APP_DEVELOPER}"
 
 	;Create uninstaller
 	WriteUninstaller "$INSTDIR\Uninstall.exe"


### PR DESCRIPTION
Hi, I plan to add this program to the [Winget](https://learn.microsoft.com/en-us/windows/package-manager/) package manager. However, Winget requires the proper uninstall registry keys for version and publisher detection (`DisplayVersion` and `Publisher`, respectively), which this program doesn't currently add. This change fixes that.

Before:
![image](https://github.com/melianmiko/OpenFreebuds/assets/56180050/536edff8-29d1-4155-bbd3-524830d7b4d6)

After:
![image](https://github.com/melianmiko/OpenFreebuds/assets/56180050/8e2cd013-c102-49b8-9f6b-60b80f0b49ff)

Note that you would have to update the `APP_VERSION` in the `.nsi` script for each new version. Maybe you can automate that 🙂

---

P.S., maybe you can provide a portable version so that it can be properly added to [Scoop](https://scoop.sh/), thanks!