### PR TITLE
Add Winget installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ _Requirements:_
 - Bluetooth (4.2 or newer) adapter with Microsoft-compatible drivers;
 - Administrator privileges
 
-_Process:_ [Download installer](https://mmk.pw/en/openfreebuds), launch them and follow
+_Process_: If you use [Winget](https://learn.microsoft.com/en-us/windows/package-manager/), just install it from there:
+```powershell
+winget install MelianMiko.OpenFreebuds
+```
+
+Otherwise, [download installer](https://mmk.pw/en/openfreebuds), launch it and follow
 on-screen instructions.
 
 ### Debian/Ubuntu and based- Linux distros


### PR DESCRIPTION
OpenFreebuds can now be installed via [Winget](https://learn.microsoft.com/en-us/windows/package-manager/):
```
winget install MelianMiko.OpenFreebuds
```

Note: If you want to update the [Winget package](https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/MelianMiko/OpenFreebuds), install [Komac](https://github.com/russellbanks/Komac) and run the `komac update` command. For example:
```bash
komac update -i MelianMiko.OpenFreebuds -v 0.13.1 -u https://st.mmk.pw/openfreebuds/openfreebuds_0.13.1_win32.exe
```
- https://github.com/microsoft/winget-pkgs/pull/138240

You can automate this via [Winget Releaser](https://github.com/vedantmgoyal2009/winget-releaser), but it only works when the binaries are hosted in the [releases](https://github.com/melianmiko/OpenFreebuds/releases) page (You can use Komac directly instead, though).