### PR TITLE
Add Scoop installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Download & install
 [![Download for Windows](./docs/img/windows.png)](https://mmk.pw/en/openfreebuds/)
 [![Available in FlatHub](./docs/img/flathub.png)](https://flathub.org/apps/pw.mmk.OpenFreebuds)
 
+#### Scoop (Windows)
+
+```powershell
+scoop bucket add extras
+scoop install openfreebuds
+```
 
 #### Debian/Ubuntu
 


### PR DESCRIPTION
I have now added openfreebuds to Scoop as of https://github.com/ScoopInstaller/Extras/pull/14841

Also, do you also plan to add Winget back to the readme?