### PR TITLE
[Device compatibility] Add FreeClip as alias for Pro 3

### DIFF
--- a/openfreebuds/driver/constants.py
+++ b/openfreebuds/driver/constants.py
@@ -12,6 +12,7 @@ DEVICE_TO_DRIVER_MAP = {
     "HUAWEI FreeBuds Pro 2": OfbDriverHuaweiPro2,
     "HUAWEI FreeBuds Pro 3": OfbDriverHuaweiPro3,
     "HUAWEI FreeBuds Pro 4": OfbDriverHuaweiPro3,
+    "HUAWEI FreeClip": OfbDriverHuaweiPro3,
     "HUAWEI FreeBuds SE": OfbDriverHuaweiSe,
     "HUAWEI FreeBuds SE 2": OfbDriverHuaweiSe2,
     "HUAWEI FreeBuds Studio": OfbDriverHuaweiStudio,


### PR DESCRIPTION
This add an Alias for the FreeClip to handle it as Pro 3.
This works, but shows noice canceling settings which the FreeClip do not have.
Using SE 2 also works but misses settings which the FreeClip has.