### PR TITLE
Add basic FreeArc device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Device compatibility
 See device page to get information about supported features.
 If your device isn't listed here, you could try to use it with profile for other model.
 
+- [HUAWEI FreeArc](./docs/devices/HUAWEI_FreeArc.md)
 - [HUAWEI FreeBuds 4i](./docs/devices/HUAWEI_FreeBuds_4i.md)
   - **HONOR Earbuds 2 / 2 SE / 2 Lite** is same
 - [HUAWEI FreeBuds 5i](./docs/devices/HUAWEI_FreeBuds_5i.md)

--- a/docs/devices/HUAWEI_FreeArc.md
+++ b/docs/devices/HUAWEI_FreeArc.md
@@ -1,0 +1,23 @@
+# HUAWEI FreeArc
+
+Protocol: Huawei SPP, port 16
+
+## Features
+
+- Fetch device information and battery level: ✅
+- Low-latency mode: ✅
+- Set double-tap action: ✅
+- Set triple-tap action: ✅
+- Set swipe action: ✅
+  - Split configuration store
+- Set long-tap action: ✅
+  - Split configuration store
+- Dual connect: ✅
+- Equalizer: ✅
+  - 5 built-in presets
+  - 2 fake built-in presets (stored in application)
+  - Up to 3 custom presets in-device memory
+
+## Not planned features
+
+- Firmware update

--- a/openfreebuds/assets/debug_profiles/huawei_arc.json
+++ b/openfreebuds/assets/debug_profiles/huawei_arc.json
@@ -1,0 +1,45 @@
+{
+  "info": {
+    "software_ver": "NotHarmonyOS 0.0.0",
+    "device_submodel": "idk",
+    "device_model": "idk",
+    "is_debug": true
+  },
+  "battery": {
+    "global": 100,
+    "left": 100,
+    "right": 100,
+    "case": 70,
+    "is_charging": "false"
+  },
+  "action": {
+    "double_tap_left": "tap_action_pause",
+    "double_tap_right": "tap_action_pause",
+    "double_tap_options": "tap_action_pause,tap_action_next,tap_action_prev,tap_action_off",
+    "double_tap_in_call": "tap_action_answer",
+    "double_tap_in_call_options": "tap_action_off,tap_action_answer",
+    "triple_tap_left": "tap_action_next",
+    "triple_tap_right": "tap_action_next",
+    "triple_tap_options": "tap_action_next,tap_action_prev,tap_action_off",
+    "long_tap_left": "tap_action_off",
+    "long_tap_right": "tap_action_off",
+    "long_tap_options": "tap_action_off,tap_action_assistant",
+    "long_tap_in_call": "tap_action_answer",
+    "long_tap_in_call_options": "tap_action_off,tap_action_answer",
+    "swipe_gesture_left": "tap_action_change_volume",
+    "swipe_gesture_right": "tap_action_change_volume",
+    "swipe_gesture_options": "tap_action_change_volume,tap_action_nextprev,tap_action_off"
+  },
+  "sound": {
+    "equalizer_preset": "equalizer_preset_default",
+    "equalizer_preset_options": "equalizer_preset_default,equalizer_preset_dynamic,equalizer_preset_hardbass,equalizer_preset_treble,equalizer_preset_voices"
+  },
+  "config": {
+    "low_latency": "false"
+  },
+  "dual_connect": {
+    "enabled": "true",
+    "preferred_device": "dba7f2d384e4",
+    "devices": "{\"010000000000\":{\"name\":\"Device 1\",\"auto_connect\":true,\"preferred\":false,\"connected\":true,\"playing\":true},\"020000000000\":{\"name\":\"Device 2\",\"auto_connect\":false,\"preferred\":false,\"connected\":false,\"playing\":false},\"030000000000\":{\"name\":\"Device 3\",\"auto_connect\":true,\"preferred\":true,\"connected\":true,\"playing\":false}}"
+  }
+}

--- a/openfreebuds/driver/constants.py
+++ b/openfreebuds/driver/constants.py
@@ -5,6 +5,7 @@ DEVICE_TO_DRIVER_MAP = {
     "HONOR Earbuds 2": OfbDriverHuawei4I,
     "HONOR Earbuds 2 SE": OfbDriverHuawei4I,
     "HONOR Earbuds 2 Lite": OfbDriverHuawei4I,
+    "HUAWEI FreeArc": OfbDriverHuaweiArc,
     "HUAWEI FreeBuds 4i": OfbDriverHuawei4I,
     "HUAWEI FreeBuds 5i": OfbDriverHuawei5I,
     "HUAWEI FreeBuds 6i": OfbDriverHuawei6I,

--- a/openfreebuds/driver/huawei/driver/per_model/__init__.py
+++ b/openfreebuds/driver/huawei/driver/per_model/__init__.py
@@ -1,3 +1,4 @@
+from .arc import OfbDriverHuaweiArc
 from .buds_4i import OfbDriverHuawei4I
 from .buds_5i import OfbDriverHuawei5I
 from .buds_6i import OfbDriverHuawei6I

--- a/openfreebuds/driver/huawei/driver/per_model/arc.py
+++ b/openfreebuds/driver/huawei/driver/per_model/arc.py
@@ -1,0 +1,27 @@
+from openfreebuds.driver.huawei.driver.generic import OfbDriverHuaweiGeneric
+from openfreebuds.driver.huawei.handler import *
+
+
+class OfbDriverHuaweiArc(OfbDriverHuaweiGeneric):
+    """
+    HUAWEI FreeArc
+    """
+    def __init__(self, address):
+        super().__init__(address)
+        self.handlers = [
+            OfbHuaweiInfoHandler(),
+            OfbHuaweiBatteryHandler(),
+            OfbHuaweiActionDoubleTapHandler(w_in_call=True),
+            OfbHuaweiActionTripleTapHandler(),
+            OfbHuaweiActionLongTapSplitHandler(w_right=True, w_in_call=True, w_anc=False),
+            OfbHuaweiActionSwipeGestureSplitHandler(),
+            OfbHuaweiLowLatencyPreferenceHandler(),
+            OfbHuaweiEqualizerPresetHandler(w_presets={
+                1: "default",
+                10: "dynamic",
+                2: "hardbass",
+                3: "treble",
+                9: "voices",
+            }, w_custom=True),
+            OfbHuaweiDualConnectHandler(),
+        ]

--- a/openfreebuds/driver/huawei/handler/__init__.py
+++ b/openfreebuds/driver/huawei/handler/__init__.py
@@ -5,6 +5,7 @@ from .action_long_tap import OfbHuaweiActionLongTapHandler
 from .action_long_tap_split import OfbHuaweiActionLongTapSplitHandler
 from .action_power_button import OfbHuaweiActionsPowerButtonHandler
 from .action_swipe_gesture import OfbHuaweiActionSwipeGestureHandler
+from .action_swipe_gesture_split import OfbHuaweiActionSwipeGestureSplitHandler
 from .anc import OfbHuaweiAncHandler, OfbHuaweiAncLegacyChangeHandler
 from .battery import OfbHuaweiBatteryHandler
 from .config_auto_pause import OfbHuaweiConfigAutoPauseHandler

--- a/openfreebuds/driver/huawei/handler/action_long_tap_split.py
+++ b/openfreebuds/driver/huawei/handler/action_long_tap_split.py
@@ -12,7 +12,7 @@ class OfbHuaweiActionLongTapSplitHandler(OfbDriverHandlerHuawei):
     For devices who store this option in two separate parameters:
     long tap action and preferred modes
 
-    Tested on 4i
+    Tested on 4i and arc
     """
 
     handler_id = "gesture_long_split"
@@ -36,10 +36,18 @@ class OfbHuaweiActionLongTapSplitHandler(OfbDriverHandlerHuawei):
         self.w_in_call = w_in_call
         self.w_anc = w_anc
 
-        self._options_lt = {
+        self._options_lt_with_assistant = {
             -1: "tap_action_off",
-            10: "tap_action_switch_anc"
+             0: "tap_action_assistant",
         }
+        self._options_lt_with_anc = {
+            -1: "tap_action_off",
+            10: "tap_action_switch_anc",
+        }
+        self._options_lt = (
+            self._options_lt_with_anc if self.w_anc
+            else self._options_lt_with_assistant
+        )
         self._options_lt_call = {
             -1: "tap_action_off",
             0: "tap_action_answer"

--- a/openfreebuds/driver/huawei/handler/action_swipe_gesture_split.py
+++ b/openfreebuds/driver/huawei/handler/action_swipe_gesture_split.py
@@ -1,0 +1,62 @@
+from openfreebuds.driver.huawei.constants import CMD_SWIPE_WRITE, CMD_SWIPE_READ
+from openfreebuds.driver.huawei.driver.generic import OfbDriverHandlerHuawei
+from openfreebuds.driver.huawei.package import HuaweiSppPackage
+from openfreebuds.utils import reverse_dict
+
+
+class OfbHuaweiActionSwipeGestureSplitHandler(OfbDriverHandlerHuawei):
+    """
+    Swipe config handler
+
+    For devices that support swiping separately left and right.
+    """
+
+    handler_id = "gesture_swipe_split"
+    commands = [CMD_SWIPE_READ, CMD_SWIPE_WRITE]
+
+    properties = [
+        ("action", "swipe_gesture_left"),
+        ("action", "swipe_gesture_right"),
+    ]
+
+    def __init__(self):
+        super().__init__()
+        self._options = {
+            -1: "tap_action_off",
+            0: "tap_action_change_volume",
+            1: "tap_action_nextprev",
+        }
+
+    async def on_init(self):
+        resp = await self.driver.send_package(HuaweiSppPackage.read_rq(CMD_SWIPE_READ, [1, 2]))
+        await self.on_package(resp)
+
+    async def on_package(self, package: HuaweiSppPackage):
+        if package.command_id != CMD_SWIPE_READ:
+            return
+
+        left = package.find_param(1)
+        right = package.find_param(2)
+        if len(left) == 1:
+            value = int.from_bytes(left, byteorder="big", signed=True)
+            await self.driver.put_property("action", "swipe_gesture_left",
+                                           self._options.get(value, value))
+        if len(right) == 1:
+            value = int.from_bytes(right, byteorder="big", signed=True)
+            await self.driver.put_property("action", "swipe_gesture_right",
+                                           self._options.get(value, value))
+        await self.driver.put_property("action", "swipe_gesture_options", ",".join(self._options.values()))
+
+    async def set_property(self, group: str, prop: str, value):
+        if "_left" in prop:
+            p_type = 1
+        elif "_right" in prop:
+            p_type = 2
+        else:
+            return
+
+        pkg = HuaweiSppPackage.change_rq(CMD_SWIPE_WRITE, [
+            (p_type, reverse_dict(self._options)[value]),
+        ])
+        await self.driver.send_package(pkg)
+        await self.driver.put_property(group, prop, value)

--- a/openfreebuds/driver/huawei/handler/config_equalizer.py
+++ b/openfreebuds/driver/huawei/handler/config_equalizer.py
@@ -11,6 +11,7 @@ KNOWN_BUILT_IN_PRESETS = {
     2: "equalizer_preset_hardbass",
     3: "equalizer_preset_treble",
     9: "equalizer_preset_voices",
+    10: "equalizer_preset_dynamic",
 }
 FAKE_BUILT_IN_PRESETS = [
     (-56, "equalizer_preset_symphony", "0f0f0afb0f190ffb322d"),

--- a/openfreebuds_qt/app/module/gestures.py
+++ b/openfreebuds_qt/app/module/gestures.py
@@ -57,6 +57,7 @@ class OfbQtGesturesModule(Ui_OfbQtGesturesModule, OfbQtCommonModule):
             "tap_action_change_volume": self.tr("Adjust volume"),
             "tap_action_assistant": self.tr("Voice assistant"),
             "tap_action_next": self.tr("Next track"),
+            "tap_action_nextprev": self.tr("Next/prev track"),
             "tap_action_off": self.tr("Disabled"),
             "tap_action_pause": self.tr("Play/pause"),
             "tap_action_prev": self.tr("Prev track"),
@@ -121,7 +122,7 @@ class OfbQtGesturesModule(Ui_OfbQtGesturesModule, OfbQtCommonModule):
                                      ui_names_map=self.gesture_names,
                                      label=self.swipe_label,
                                      left_combo=self.swipe_left,
-                                     is_separate=False))
+                                     right_combo=self.swipe_right))
 
     async def update_ui(self, event: OfbCoreEvent):
         if not event.is_changed("action") and not event.kind_match(OfbEventKind.DEVICE_CHANGED):

--- a/openfreebuds_qt/designer/module_geatures.ui
+++ b/openfreebuds_qt/designer/module_geatures.ui
@@ -138,7 +138,10 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1" colspan="2">
+   <item row="10" column="2">
+    <widget class="QComboBox" name="swipe_right"/>
+   </item>
+   <item row="10" column="1">
     <widget class="QComboBox" name="swipe_left"/>
    </item>
    <item row="5" column="2">
@@ -188,6 +191,7 @@
   <tabstop>long_in_call</tabstop>
   <tabstop>power_left</tabstop>
   <tabstop>swipe_left</tabstop>
+  <tabstop>swipe_right</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/openfreebuds_qt/qt_i18n.py
+++ b/openfreebuds_qt/qt_i18n.py
@@ -17,6 +17,7 @@ def get_eq_preset_names():
         "equalizer_preset_hardbass": QApplication.translate("EqPresetName", "Bass-boost"),
         "equalizer_preset_treble": QApplication.translate("EqPresetName", "Treble-boost"),
         "equalizer_preset_voices": QApplication.translate("EqPresetName", "Voices"),
+        "equalizer_preset_dynamic": QApplication.translate("EqPresetName", "Dynamic"),
         "equalizer_preset_symphony": QApplication.translate("EqPresetName", "Symphony"),
         "equalizer_preset_hi_fi_live": QApplication.translate("EqPresetName", "Hi-Fi Live"),
     }


### PR DESCRIPTION
Uses SPP port 16.
Quite similar to 4i. But featuring also some new values/features.

Fixes #85 

Unfinished:
- The two "fake" equalizer settings are little vague. But left as is.
- Also unclear to me if other devices -- e.g. by firmware update -- meanwhile also support newly added values e.g. for "Next+Prev" swipe action, spotted new "dynamic" equalizer setting, or for starting assistant functions via long tap.
- For devices with combined (unsplit) swipe, the swipe setting UI likely disappears, as those would not have "swipe_gesture_left". But presumably this is already issue for devices using unsplit long tap handler within gesture.py, and needs some adaptations there. OTOH, likely OFB<1.0 still is under preparation.

So this is for now some draft, which works for my local FreeArc, but needs realignments on overall integration. Such are also difficult to judge without owning other devices.