### PR TITLE
Add refresh battery button to system tray menu

### DIFF
--- a/openfreebuds/driver/generic/base.py
+++ b/openfreebuds/driver/generic/base.py
@@ -100,3 +100,7 @@ class OfbDriverGeneric:
             self._store[group][prop] = value
 
         await self.changes.send_message(OfbEventKind.PROPERTY_CHANGED, group, prop, value)
+
+    async def request_property_update(self, handler_id: str):
+        """Request a property update from a specific handler"""
+        raise NotImplementedError()

--- a/openfreebuds/driver/huawei/driver/generic.py
+++ b/openfreebuds/driver/huawei/driver/generic.py
@@ -131,6 +131,14 @@ class OfbDriverHuaweiGeneric(OfbDriverSppGeneric):
         for pkg_id in handler.ignore_commands:
             self.__on_package_handlers[pkg_id] = _empty_handler
 
+    async def request_property_update(self, handler_id: str):
+        """Request a property update from a specific handler"""
+        for handler in self.handlers:
+            if handler.handler_id == handler_id and hasattr(handler, 'request_update'):
+                await handler.request_update()
+                return True
+        return False
+
 
 class OfbDriverHandlerHuawei(OfbDriverHandlerGeneric):
     handler_id: str = ""

--- a/openfreebuds/driver/huawei/handler/battery.py
+++ b/openfreebuds/driver/huawei/handler/battery.py
@@ -32,3 +32,8 @@ class OfbHuaweiBatteryHandler(OfbDriverHandlerHuawei):
         if 3 in package.parameters and len(package.parameters[3]) > 0:
             out["is_charging"] = json.dumps(b"\x01" in package.parameters[3])
         await self.driver.put_property("battery", None, out)
+
+    async def request_update(self):
+        """Request battery update from device"""
+        resp = await self.driver.send_package(HuaweiSppPackage.read_rq(CMD_BATTERY_READ, [1, 2, 3]))
+        await self.on_package(resp)

--- a/openfreebuds/manager/generic.py
+++ b/openfreebuds/manager/generic.py
@@ -42,6 +42,9 @@ class IOpenFreebuds(Subscription):
     async def run_shortcut(self, *args, no_catch: bool = False):
         raise NotImplementedError("Not implemented")
 
+    async def request_property_update(self, handler_id: str):
+        raise NotImplementedError("Not implemented")
+
     @asynccontextmanager
     async def locked_device(self):
         raise NotImplementedError("Not implemented")

--- a/openfreebuds/manager/main.py
+++ b/openfreebuds/manager/main.py
@@ -113,6 +113,13 @@ class OfbManager(IOpenFreebuds):
         log.info(f"Execute shortcut action {args}")
         return await self._shortcuts.execute(*args, no_catch=no_catch)
 
+    @rpc
+    async def request_property_update(self, handler_id: str):
+        """Request a property update from a specific handler"""
+        if self._driver is None:
+            raise OfbNoDeviceError("Attempt to request update without device")
+        return await self._driver.request_property_update(handler_id)
+
     @asynccontextmanager
     async def locked_device(self):
         try:

--- a/openfreebuds/shortcuts.py
+++ b/openfreebuds/shortcuts.py
@@ -84,6 +84,14 @@ class OfbShortcuts:
     async def do_show_main_window(self):
         await self.ofb.send_message(OfbEventKind.QT_BRING_SETTINGS_UP)
 
+    async def do_refresh_battery(self):
+        """Request battery update from device"""
+        await self.ofb.request_property_update("battery")
+
+    async def is_refresh_battery_available(self):
+        state = await self.ofb.get_state()
+        return state == IOpenFreebuds.STATE_CONNECTED
+
     async def do_disconnect(self):
         state = await self.ofb.get_state()
         if state == IOpenFreebuds.STATE_DISCONNECTED:

--- a/openfreebuds_qt/tray/menu.py
+++ b/openfreebuds_qt/tray/menu.py
@@ -60,6 +60,9 @@ class OfbQtTrayMenu(OfbQtTrayMenuCommon):
             "case": self.add_item("", visible=False, enabled=False),
             "global": self.add_item("", visible=False, enabled=False),
         }
+        self.refresh_battery_action = self.add_item(text=self.tr("Refresh battery"),
+                                                     callback=self.do_refresh_battery,
+                                                     visible=False)
         self.add_separator()
 
         # ANC settings
@@ -98,6 +101,7 @@ class OfbQtTrayMenu(OfbQtTrayMenuCommon):
             self.connect_action.setVisible(state == IOpenFreebuds.STATE_DISCONNECTED)
             self.disconnect_action.setVisible(self.is_connected)
             self.set_section_visible(self.battery_section, self.is_connected)
+            self.refresh_battery_action.setVisible(self.is_connected)
             self.set_section_visible(self.anc_section, self.is_connected)
             self.equalizer_action.setVisible(
                 self.is_connected
@@ -197,6 +201,10 @@ class OfbQtTrayMenu(OfbQtTrayMenuCommon):
     @asyncSlot()
     async def do_bugreport(self):
         await OfbQtReportTool(self.ctx).create_and_show()
+
+    @asyncSlot()
+    async def do_refresh_battery(self):
+        await self.ofb.run_shortcut("refresh_battery")
 
     @asyncSlot()
     async def do_exit(self):


### PR DESCRIPTION
Added functionality to manually refresh battery values (left, right, case) from the system tray context menu.

Changes:
- Added request_update() method to OfbHuaweiBatteryHandler
- Added request_property_update() to driver interface and implementation
- Added request_property_update() to manager interface and implementation
- Added refresh_battery shortcut with availability check
- Added "Refresh battery" menu item in system tray menu
- Menu item only visible when device is connected

The refresh button sends a battery read request to the device and updates the displayed battery levels.