### PR TITLE
[Feature] MacOs support

### DIFF
--- a/openfreebuds/driver/generic/spp.py
+++ b/openfreebuds/driver/generic/spp.py
@@ -1,8 +1,8 @@
 import asyncio
-import socket
 from contextlib import suppress
 
 from openfreebuds.driver.generic import OfbDriverGeneric
+from openfreebuds.driver.generic.spp_transport import get_default_transport
 from openfreebuds.exceptions import FbStartupError
 from openfreebuds.utils.logger import create_logger
 
@@ -26,12 +26,11 @@ class OfbDriverSppGeneric(OfbDriverGeneric):
 
     async def start(self):
         try:
-            sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM)
-            sock.settimeout(2)
-            await asyncio.sleep(self._spp_connect_delay)
-
-            sock.connect((self.device_address, self._spp_service_port))
-            reader, writer = await asyncio.open_connection(sock=sock)
+            reader, writer = await get_default_transport().open(
+                self.device_address,
+                self._spp_service_port,
+                connect_delay=self._spp_connect_delay,
+            )
         except (ConnectionResetError, ConnectionRefusedError, ConnectionAbortedError, OSError, ValueError):
             raise FbStartupError("Driver startup failed")
 

--- a/openfreebuds/driver/generic/spp_transport.py
+++ b/openfreebuds/driver/generic/spp_transport.py
@@ -1,0 +1,33 @@
+import asyncio
+import socket
+import sys
+from typing import Protocol
+
+
+class SppTransport(Protocol):
+    async def open(
+        self,
+        address: str,
+        channel: int,
+        *,
+        connect_delay: float = 0,
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]: ...
+
+
+class _BluetoothSocketTransport:
+    """SPP transport backed by Python's stdlib AF_BLUETOOTH socket (Linux, Windows)."""
+
+    async def open(self, address, channel, *, connect_delay=0):
+        sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM)
+        sock.settimeout(2)
+        if connect_delay:
+            await asyncio.sleep(connect_delay)
+        sock.connect((address, channel))
+        return await asyncio.open_connection(sock=sock)
+
+
+def get_default_transport() -> SppTransport:
+    if sys.platform == "darwin":
+        from openfreebuds_backend.darwin.rfcomm_transport import IOBluetoothRFCOMMTransport
+        return IOBluetoothRFCOMMTransport()
+    return _BluetoothSocketTransport()

--- a/openfreebuds_backend/__init__.py
+++ b/openfreebuds_backend/__init__.py
@@ -9,3 +9,6 @@ elif platform.system() == "Windows":
     from openfreebuds_backend.windows.bt_win32 import *
     from openfreebuds_backend.windows.ui_win32 import *
     from openfreebuds_backend.windows.misc_win32 import *
+elif platform.system() == "Darwin":
+    from openfreebuds_backend.darwin.bt_macos import *
+    from openfreebuds_backend.darwin.misc_macos import *

--- a/openfreebuds_backend/darwin/_sdp.py
+++ b/openfreebuds_backend/darwin/_sdp.py
@@ -1,0 +1,155 @@
+"""SDP attribute walkers for IOBluetoothSDPServiceRecord, used to resolve RFCOMM
+channel IDs without relying on PyObjC's broken bridging metadata for
+`getRFCOMMChannelID:` and friends. Validated against a real FreeBuds Pro 4."""
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("OfbDarwinSDP")
+
+# SDP type codes (Bluetooth Core spec, Vol3 Part B)
+_SDP_TYPE_UINT = 1
+_SDP_TYPE_UUID = 3
+_SDP_TYPE_SEQ = 6
+_SDP_TYPE_ALT = 7
+
+# Well-known SDP UUIDs (16-bit short form)
+_UUID_RFCOMM = 0x0003
+_UUID_SPP = 0x1101
+
+# SDP attribute IDs
+_ATTR_SERVICE_CLASS_ID_LIST = 0x0001
+_ATTR_PROTOCOL_DESCRIPTOR_LIST = 0x0004
+
+_BT_BASE_UUID_TAIL = bytes.fromhex("00001000800000805F9B34FB")
+
+
+def _attrs_as_dict(svc) -> dict:
+    raw = svc.attributes()
+    if raw is None:
+        return {}
+    out = {}
+    for k in raw:
+        try:
+            out[int(k)] = raw[k]
+        except Exception:
+            pass
+    return out
+
+
+def _seq(elem) -> list:
+    try:
+        td = elem.getTypeDescriptor()
+        if td not in (_SDP_TYPE_SEQ, _SDP_TYPE_ALT):
+            return []
+        arr = elem.getArrayValue()
+        return list(arr) if arr is not None else []
+    except Exception:
+        return []
+
+
+def _uint(elem):
+    try:
+        if elem.getTypeDescriptor() != _SDP_TYPE_UINT:
+            return None
+        n = elem.getNumberValue()
+        return int(n) if n is not None else None
+    except Exception:
+        return None
+
+
+def _uuid16(elem):
+    try:
+        if elem.getTypeDescriptor() != _SDP_TYPE_UUID:
+            return None
+        u = elem.getUUIDValue()
+        if u is None:
+            return None
+        # IOBluetoothSDPUUID inherits from NSData. Normalize to 16-bit when possible.
+        try:
+            u16 = u.getUUIDWithLength_(2)
+            data = bytes(u16) if u16 is not None else None
+            if data and len(data) == 2:
+                return int.from_bytes(data, "big")
+        except Exception:
+            pass
+        try:
+            length = int(u.length())
+            data = bytes(u)[:length] if length else b""
+        except Exception:
+            data = b""
+        if len(data) == 2:
+            return int.from_bytes(data, "big")
+        if len(data) == 4:
+            v = int.from_bytes(data, "big")
+            return (v & 0xFFFF) if (v >> 16) == 0 else v
+        if len(data) == 16 and data[4:] == _BT_BASE_UUID_TAIL:
+            return int.from_bytes(data[0:4], "big") & 0xFFFF
+        return None
+    except Exception:
+        return None
+
+
+def _service_rfcomm_channel(svc):
+    attrs = _attrs_as_dict(svc)
+    pdl = attrs.get(_ATTR_PROTOCOL_DESCRIPTOR_LIST)
+    if pdl is None:
+        return None
+    for protocol_entry in _seq(pdl):
+        items = _seq(protocol_entry)
+        if not items:
+            continue
+        if _uuid16(items[0]) == _UUID_RFCOMM and len(items) >= 2:
+            return _uint(items[1])
+    return None
+
+
+def _service_class_uuids(svc):
+    attrs = _attrs_as_dict(svc)
+    out = []
+    scl = attrs.get(_ATTR_SERVICE_CLASS_ID_LIST)
+    if scl is None:
+        return out
+    for entry in _seq(scl):
+        u = _uuid16(entry)
+        if u is not None:
+            out.append(u)
+    return out
+
+
+def find_spp_channel(device, fallback: int | None = None) -> int | None:
+    """Return the best-guess RFCOMM channel for SPP on `device`.
+
+    Priority:
+    1. Service whose ServiceClassIDList includes SPP (0x1101).
+    2. Service whose RFCOMM channel matches `fallback` (the per-model port).
+    3. Service whose name is exactly "Serial Port".
+    4. None — caller falls back to `fallback`.
+    """
+    candidates: list[tuple[int, str | None, list[int]]] = []
+    services = device.services() or []
+    for svc in services:
+        ch = _service_rfcomm_channel(svc)
+        if ch is None:
+            continue
+        name = svc.getServiceName() if hasattr(svc, "getServiceName") else None
+        uuids = _service_class_uuids(svc)
+        candidates.append((ch, name, uuids))
+
+    if not candidates:
+        log.debug("No RFCOMM-capable services found on device")
+        return None
+
+    log.debug(f"RFCOMM candidates: {candidates}")
+
+    for ch, name, uuids in candidates:
+        if _UUID_SPP in uuids:
+            return ch
+    if fallback is not None:
+        for ch, _name, _uuids in candidates:
+            if ch == fallback:
+                return ch
+    for ch, name, _uuids in candidates:
+        if name and "serial" in name.lower():
+            return ch
+    return None

--- a/openfreebuds_backend/darwin/bt_macos.py
+++ b/openfreebuds_backend/darwin/bt_macos.py
@@ -1,0 +1,82 @@
+import asyncio
+import logging
+from contextlib import suppress
+
+import IOBluetooth
+
+log = logging.getLogger("OfbDarwinBackend")
+
+
+def _canonical_address(addr: str) -> str:
+    """Normalize a Bluetooth MAC to colon-separated upper-case form."""
+    return addr.replace("-", ":").upper()
+
+
+def _find_device(address: str):
+    addr = _canonical_address(address)
+    # IOBluetoothDevice.deviceWithAddressString_ accepts both dash and colon forms
+    return IOBluetoothDevice_deviceWithAddressString(addr) or \
+        IOBluetoothDevice_deviceWithAddressString(addr.replace(":", "-").lower())
+
+
+def IOBluetoothDevice_deviceWithAddressString(addr: str):
+    return IOBluetooth.IOBluetoothDevice.deviceWithAddressString_(addr)
+
+
+async def bt_is_connected(address):
+    with suppress(Exception):
+        device = _find_device(address)
+        if device is None:
+            return None
+        return bool(device.isConnected())
+    return False
+
+
+async def bt_connect(address):
+    try:
+        device = _find_device(address)
+        if device is None:
+            return None
+        err = await asyncio.to_thread(device.openConnection)
+        await asyncio.sleep(1)
+        return err == 0
+    except Exception:
+        log.exception(f"Failed to connect {address}")
+        return False
+
+
+async def bt_disconnect(address):
+    try:
+        device = _find_device(address)
+        if device is None:
+            return None
+        err = await asyncio.to_thread(device.closeConnection)
+        await asyncio.sleep(1)
+        return err == 0
+    except Exception:
+        log.exception(f"Failed to disconnect {address}")
+        return False
+
+
+async def bt_list_devices():
+    results = []
+    with suppress(Exception):
+        devices = await asyncio.to_thread(IOBluetooth.IOBluetoothDevice.pairedDevices)
+        if not devices:
+            return results
+        for dev in devices:
+            try:
+                name = dev.name() or dev.nameOrAddress() or "(unnamed)"
+                raw_addr = dev.addressString() or ""
+                addr = _canonical_address(raw_addr)
+                connected = bool(dev.isConnected())
+                if not addr:
+                    continue
+                results.append({
+                    "name": str(name),
+                    "address": addr,
+                    "connected": connected,
+                })
+            except Exception:
+                log.debug("Skip broken IOBluetooth device", exc_info=True)
+    return results

--- a/openfreebuds_backend/darwin/misc_macos.py
+++ b/openfreebuds_backend/darwin/misc_macos.py
@@ -1,0 +1,91 @@
+import logging
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+log = logging.getLogger("OfbDarwinBackend")
+
+AUTOSTART_AVAILABLE = True
+AUTOUPDATE_AVAILABLE = False  # Defer to Homebrew or DMG-based updates
+GLOBAL_HOTKEYS_AVAILABLE = True  # pynput supports macOS (requires Accessibility permission)
+
+_LAUNCH_AGENT_LABEL = "pw.mmk.OpenFreebuds"
+
+
+def get_app_storage_path():
+    return Path.home() / "Library" / "Application Support" / "openfreebuds"
+
+
+def open_file(path):
+    subprocess.Popen(["open", str(path)])
+
+
+def is_run_at_boot():
+    return _launch_agent_path().is_file()
+
+
+async def set_run_at_boot(val):
+    path = _launch_agent_path()
+    if val:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            plistlib.dump(_build_launch_agent_plist(), f)
+        log.debug(f"Wrote LaunchAgent: {path}")
+        _launchctl("load", "-w", str(path))
+    else:
+        if path.is_file():
+            _launchctl("unload", "-w", str(path))
+            path.unlink()
+            log.debug(f"Removed LaunchAgent: {path}")
+
+
+def is_dark_taskbar():
+    try:
+        # NSUserDefaults reads the global preference set by macOS for the current user
+        from Foundation import NSUserDefaults
+        defaults = NSUserDefaults.standardUserDefaults()
+        style = defaults.stringForKey_("AppleInterfaceStyle")
+        return style == "Dark"
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+
+def _launch_agent_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{_LAUNCH_AGENT_LABEL}.plist"
+
+
+def _program_arguments() -> list[str]:
+    """Best-effort reconstruction of the command launchd should invoke."""
+    cli = shutil.which("openfreebuds_qt")
+    if cli:
+        return [cli]
+    # Fall back to the current Python with the entry-point module
+    return [sys.executable, "-m", "openfreebuds_qt"]
+
+
+def _build_launch_agent_plist() -> dict:
+    return {
+        "Label": _LAUNCH_AGENT_LABEL,
+        "ProgramArguments": _program_arguments(),
+        "RunAtLoad": True,
+        "KeepAlive": False,
+        "ProcessType": "Interactive",
+    }
+
+
+def _launchctl(*args: str) -> None:
+    try:
+        subprocess.run(
+            ["launchctl", *args],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except Exception:
+        log.debug("launchctl invocation failed", exc_info=True)

--- a/openfreebuds_backend/darwin/rfcomm_transport.py
+++ b/openfreebuds_backend/darwin/rfcomm_transport.py
@@ -1,0 +1,322 @@
+"""IOBluetoothRFCOMMChannel ↔ asyncio bridge.
+
+Exposes `IOBluetoothRFCOMMTransport.open(...)` returning an asyncio
+`StreamReader`-compatible reader and `StreamWriter`-compatible writer, so
+[openfreebuds/driver/generic/spp.py](openfreebuds/driver/generic/spp.py) and
+its subclasses work unchanged on macOS.
+
+Implementation notes:
+
+- IOBluetoothRFCOMMChannel delegate callbacks are delivered on the main
+  thread's NSRunLoop. asyncio runs on the main thread but does not pump
+  NSRunLoop, so we drive it ourselves: a recurring `loop.call_later` tick
+  runs `NSRunLoop.runMode:beforeDate:` for one zero-duration iteration,
+  which delivers any queued delegate callbacks without blocking.
+- Synchronous IOBluetooth calls (`openConnection`, `performSDPQuery`,
+  device lookup) are off-loaded via `asyncio.to_thread`.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from typing import Optional
+
+import objc
+from Foundation import (
+    NSDate,
+    NSDefaultRunLoopMode,
+    NSObject,
+    NSRunLoop,
+)
+import IOBluetooth
+
+from openfreebuds_backend.darwin._sdp import find_spp_channel
+
+log = logging.getLogger("OfbDarwinRFCOMM")
+
+_PUMP_INTERVAL = 0.02  # 50 Hz NSRunLoop pump from asyncio
+
+
+# ---------------------------------------------------------------------------
+# Delegate
+# ---------------------------------------------------------------------------
+
+class _RFCOMMDelegate(NSObject):
+    def initWithBridge_(self, bridge):
+        self = objc.super(_RFCOMMDelegate, self).init()
+        if self is None:
+            return None
+        self._bridge = bridge
+        return self
+
+    def rfcommChannelOpenComplete_status_(self, channel, status):
+        self._bridge._on_open_complete(int(status))
+
+    def rfcommChannelData_data_length_(self, channel, data, length):
+        if isinstance(data, (bytes, bytearray)):
+            chunk = bytes(data[: int(length)])
+        else:
+            try:
+                chunk = bytes(data)
+            except Exception:
+                chunk = b""
+        self._bridge._on_data(chunk)
+
+    def rfcommChannelClosed_(self, channel):
+        self._bridge._on_closed()
+
+    def rfcommChannelWriteComplete_refcon_status_(self, channel, refcon, status):
+        try:
+            ref = int(refcon) if refcon is not None else None
+        except Exception:
+            ref = None
+        self._bridge._on_write_complete(ref, int(status))
+
+
+# ---------------------------------------------------------------------------
+# Bridge — turns delegate events into asyncio futures / queue items
+# ---------------------------------------------------------------------------
+
+class _Bridge:
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self._loop = loop
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._open_future: asyncio.Future = loop.create_future()
+        self._write_futures: dict[int, asyncio.Future] = {}
+        self._closed_flag = False
+
+    def _on_open_complete(self, status: int):
+        if self._open_future.done():
+            return
+        if status == 0:
+            self._open_future.set_result(0)
+        else:
+            self._open_future.set_exception(
+                ConnectionRefusedError(f"openRFCOMMChannel failed, status={status}")
+            )
+
+    def _on_data(self, chunk: bytes):
+        if not chunk:
+            return
+        self._queue.put_nowait(chunk)
+
+    def _on_closed(self):
+        if self._closed_flag:
+            return
+        self._closed_flag = True
+        self._queue.put_nowait(None)
+        if not self._open_future.done():
+            self._open_future.set_exception(ConnectionResetError("channel closed"))
+        for ref, fut in list(self._write_futures.items()):
+            if not fut.done():
+                fut.set_exception(ConnectionResetError("channel closed"))
+            self._write_futures.pop(ref, None)
+
+    def _on_write_complete(self, ref, status: int):
+        if ref is None:
+            return
+        fut = self._write_futures.pop(ref, None)
+        if fut is None or fut.done():
+            return
+        if status == 0:
+            fut.set_result(None)
+        else:
+            fut.set_exception(OSError(f"RFCOMM write failed, status={status}"))
+
+
+# ---------------------------------------------------------------------------
+# StreamReader/StreamWriter look-alikes
+# ---------------------------------------------------------------------------
+
+class _RFCOMMReader:
+    def __init__(self, bridge: _Bridge):
+        self._bridge = bridge
+        self._buffer = bytearray()
+        self._eof = False
+
+    async def read(self, n: int = -1) -> bytes:
+        if n == 0:
+            return b""
+        while not self._buffer and not self._eof:
+            chunk = await self._bridge._queue.get()
+            if chunk is None:
+                self._eof = True
+                break
+            self._buffer.extend(chunk)
+        if not self._buffer:
+            return b""
+        if n < 0 or n >= len(self._buffer):
+            out = bytes(self._buffer)
+            self._buffer.clear()
+            return out
+        out = bytes(self._buffer[:n])
+        del self._buffer[:n]
+        return out
+
+
+class _RFCOMMWriter:
+    def __init__(self, transport: "IOBluetoothRFCOMMTransport", bridge: _Bridge):
+        self._transport = transport
+        self._bridge = bridge
+        self._pending: list[asyncio.Future] = []
+        self._closing = False
+
+    def write(self, data) -> None:
+        if self._closing:
+            raise ConnectionResetError("writer is closing")
+        if not data:
+            return
+        fut = self._transport._submit_write(bytes(data))
+        self._pending.append(fut)
+
+    async def drain(self) -> None:
+        if not self._pending:
+            return
+        pending, self._pending = self._pending, []
+        for fut in pending:
+            await fut
+
+    def close(self) -> None:
+        if self._closing:
+            return
+        self._closing = True
+        self._transport._close()
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+class IOBluetoothRFCOMMTransport:
+    """Single-use RFCOMM transport. Create one per OpenFreebuds driver instance."""
+
+    def __init__(self):
+        self._channel = None
+        self._delegate: Optional[_RFCOMMDelegate] = None
+        self._bridge: Optional[_Bridge] = None
+        self._next_refcon = 1
+        self._stopped = False
+        self._pump_handle: Optional[asyncio.TimerHandle] = None
+
+    async def open(
+        self,
+        address: str,
+        channel: int,
+        *,
+        connect_delay: float = 0,
+    ) -> tuple[_RFCOMMReader, _RFCOMMWriter]:
+        loop = asyncio.get_running_loop()
+        self._bridge = _Bridge(loop)
+
+        device = await asyncio.to_thread(_get_device, address)
+        if device is None:
+            raise ConnectionRefusedError(f"Bluetooth device not found: {address}")
+
+        if not bool(device.isConnected()):
+            log.info(f"Device {address} is not connected; calling openConnection()")
+            err = await asyncio.to_thread(device.openConnection)
+            if err != 0:
+                raise ConnectionRefusedError(f"openConnection failed: {err}")
+
+        # Start the NSRunLoop pump *before* opening the channel so we don't
+        # miss the openComplete delegate callback.
+        self._start_pump(loop)
+
+        with suppress(Exception):
+            await asyncio.to_thread(device.performSDPQuery_, None)
+
+        resolved = await asyncio.to_thread(find_spp_channel, device, channel)
+        if resolved is None:
+            log.warning(
+                f"SDP lookup found no SPP service on {address}; "
+                f"falling back to channel {channel}"
+            )
+            resolved = channel
+        log.info(f"Opening RFCOMM channel {resolved} on {address}")
+
+        if connect_delay:
+            await asyncio.sleep(connect_delay)
+
+        self._delegate = _RFCOMMDelegate.alloc().initWithBridge_(self._bridge)
+        err, ch = device.openRFCOMMChannelSync_withChannelID_delegate_(
+            None, int(resolved), self._delegate
+        )
+        if err != 0:
+            self._stop_pump()
+            raise ConnectionRefusedError(f"openRFCOMMChannelSync failed, err={err}")
+        self._channel = ch
+
+        try:
+            await asyncio.wait_for(self._bridge._open_future, timeout=10)
+        except asyncio.TimeoutError:
+            self._stop_pump()
+            raise ConnectionRefusedError("RFCOMM channel open timed out")
+
+        return _RFCOMMReader(self._bridge), _RFCOMMWriter(self, self._bridge)
+
+    # ------------------------------------------------------------------
+    def _start_pump(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self._pump_handle is not None:
+            return
+        self._pump_handle = loop.call_soon(self._pump, loop)
+
+    def _stop_pump(self) -> None:
+        self._stopped = True
+        if self._pump_handle is not None:
+            with suppress(Exception):
+                self._pump_handle.cancel()
+            self._pump_handle = None
+
+    def _pump(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self._stopped:
+            return
+        try:
+            NSRunLoop.currentRunLoop().runMode_beforeDate_(
+                NSDefaultRunLoopMode,
+                NSDate.dateWithTimeIntervalSinceNow_(0),
+            )
+        except Exception:
+            log.exception("NSRunLoop pump raised")
+        if not self._stopped:
+            self._pump_handle = loop.call_later(_PUMP_INTERVAL, self._pump, loop)
+
+    # ------------------------------------------------------------------
+    def _submit_write(self, data: bytes) -> asyncio.Future:
+        assert self._bridge is not None
+        loop = self._bridge._loop
+        if self._channel is None or self._stopped:
+            fut = loop.create_future()
+            fut.set_exception(ConnectionResetError("channel closed"))
+            return fut
+        ref = self._next_refcon
+        self._next_refcon += 1
+        fut = loop.create_future()
+        self._bridge._write_futures[ref] = fut
+        try:
+            err = self._channel.writeAsync_length_refcon_(data, len(data), ref)
+        except Exception as e:
+            log.exception("writeAsync raised")
+            self._bridge._on_write_complete(ref, -1)
+            return fut
+        if err != 0:
+            self._bridge._on_write_complete(ref, int(err))
+        return fut
+
+    # ------------------------------------------------------------------
+    def _close(self) -> None:
+        if self._stopped:
+            return
+        if self._channel is not None:
+            with suppress(Exception):
+                self._channel.closeChannel()
+        self._stop_pump()
+
+
+def _get_device(address: str):
+    addr = address.replace("-", ":").upper()
+    return IOBluetooth.IOBluetoothDevice.deviceWithAddressString_(addr) or \
+        IOBluetooth.IOBluetoothDevice.deviceWithAddressString_(addr.replace(":", "-").lower())

--- a/openfreebuds_qt/app/dialog/first_run.py
+++ b/openfreebuds_qt/app/dialog/first_run.py
@@ -32,7 +32,7 @@ class OfbQtFirstRunDialog(Ui_OfbQtFirstRunDialog, QDialog):
         self.autostart_checkbox.setChecked(AUTOSTART_AVAILABLE)
         self.autostart_checkbox.setEnabled(AUTOSTART_AVAILABLE)
 
-        preview_fn = "ofb_linux_preview" if sys.platform == 'linux' else "ofb_win32_preview"
+        preview_fn = "ofb_win32_preview" if sys.platform == "win32" else "ofb_linux_preview"
         preview_image = get_img_colored(preview_fn,
                                         color=self.palette().text().color().getRgb(),
                                         base_dir="image")

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "no-flatpak"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:802b5f17f512f55c2ceebf7e3a056562be1f2f285b7e9241ee9471c170e81143"
+content_hash = "sha256:1179171ccc263dfae880a81b4a13ec10965b3d31e826fc2750a91ff8d392ff1e"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.14"
@@ -738,6 +738,25 @@ files = [
     {file = "pyobjc_framework_coretext-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7cbb2c28580e6704ce10b9a991ccd9563a22b3a75f67c36cf612544bd8b21b5f"},
     {file = "pyobjc_framework_coretext-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:14100d1e39efb30f57869671fb6fce8d668f80c82e25e7930fb364866e5c0dab"},
     {file = "pyobjc_framework_coretext-12.1.tar.gz", hash = "sha256:e0adb717738fae395dc645c9e8a10bb5f6a4277e73cba8fa2a57f3b518e71da5"},
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetooth"
+version = "12.1"
+requires_python = ">=3.10"
+summary = "Wrappers for the framework IOBluetooth on macOS"
+groups = ["default"]
+marker = "python_version >= \"3.11\" and python_version < \"3.14\" and sys_platform == \"darwin\""
+dependencies = [
+    "pyobjc-core>=12.1",
+    "pyobjc-framework-Cocoa>=12.1",
+]
+files = [
+    {file = "pyobjc_framework_iobluetooth-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:77959f2ecf379aa41eb0848fdb25da7c322f9f4a82429965c87c4bc147137953"},
+    {file = "pyobjc_framework_iobluetooth-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:111a6e54be9e9dcf77fa2bf84fdac09fae339aa33087d8647ea7ffbd34765d4c"},
+    {file = "pyobjc_framework_iobluetooth-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2ee0d4fdddf871fb89c49033495ae49973cc8b0e8de50c2e60c92355ce3bea86"},
+    {file = "pyobjc_framework_iobluetooth-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0cd2ea9384e93913703bf40641196a930af83c2f6f62f59f8606b7162fe1caa3"},
+    {file = "pyobjc_framework_iobluetooth-12.1.tar.gz", hash = "sha256:8a434118812f4c01dfc64339d41fe8229516864a59d2803e9094ee4cbe2b7edd"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pynput<2.0.0,>=1.7.7",
     "dbus-next<1.0.0,>=0.2.3",
     "winsdk==1.0.0b10; sys_platform == 'win32'",
+    "pyobjc-framework-IOBluetooth>=12.1; sys_platform == 'darwin'",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
# Add macOS support

I have a HUAWEI FreeBuds Pro 4 and a Mac, and I wanted the app to work for me. This PR is the result. Splitting it for review in case it's useful upstream. No pressure to merge if the IOBluetooth deprecation risk (see below) makes maintaining it long-term unattractive.

5 commits, all macOS-specific code lives under a new `openfreebuds_backend/darwin/` package. The only file touched outside of `darwin/` is `openfreebuds/driver/generic/spp.py`, where a mechanical refactor moves the hardcoded `socket(AF_BLUETOOTH, …)` behind a factory so other platforms can plug in. Linux and Windows behavior is unchanged.

<img width="1191" height="672" alt="image" src="https://github.com/user-attachments/assets/7215d27d-49d4-4497-8997-43937cb77ca4" />

Some styles are not 100% there, but they can be improved upon. Most commands work already for the FreeBuds 4 Pro out of the box, which is quite nice.

## What works

Tested with a HUAWEI FreeBuds Pro 4 paired in macOS 26 (Tahoe) on Apple Silicon, running `pdm run openfreebuds_qt`:

- Tray icon and main window come up
- Device discovery and selection work
- Every handler initializes successfully: battery, ANC, EQ presets
  (including user-saved ones), gestures, dual-connect, low-latency, voice
  language, device info
- Bidirectional events: tapping the headset's touch surface to switch ANC
  produces a TX command from the app and the new state appears in the UI

`pdm run pytest` passes at every commit (8/8).

## Commits

| # | Title | Notes |
|---|---|---|
| 1 | `[Refactor] Extract SPP socket creation behind a transport factory` | Pure refactor; Linux/Windows path preserved verbatim. Start here. |
| 2 | `[macOS] Add Bluetooth discovery and connection backend` | Adds `pyobjc-framework-IOBluetooth` (darwin-only dep). Mirrors `bluez_io.py` and `bt_win32.py`. |
| 3 | `[macOS] Add RFCOMM transport bridging IOBluetooth to asyncio` | The biggest commit. The message has the technical detail — SDP-based channel resolution, NSRunLoop pumped from asyncio, PyObjC bridging quirks. |
| 4 | `[macOS] Add miscellaneous backend (storage, autostart, theme detect)` | LaunchAgent autostart, `~/Library/Application Support/openfreebuds`, dark-mode detection. |
| 5 | `[macOS] Wire darwin backend into dispatcher and first-run dialog` | Just some glue. |

## Caveats

**IOBluetooth is deprecated** in macOS 14, still present and working in 26. Apple has signaled removal for a couple releases now, but classic Bluetooth SPP has no replacement in CoreBluetooth (BLE only). Whenever the framework goes away, this port will need a rewrite. I'd rather have something that works today, but it's worth flagging upfront.

**Pairing has to happen via macOS System Settings** before the app sees the device. No in-app first-pair flow.

**Hotkeys need Accessibility permission** the first time they're used. macOS prompts; pynput handles it; no in-app explanation yet.

## Not in this PR

- `.app` bundle / DMG / PyInstaller-darwin spec
- Code signing or notarization
- macOS runner in `on_push.yml`
- README updates for the macOS install path (happy to add — say the word)

## Test plan

- [x] `pytest` 8/8 on macOS 26 Apple Silicon, every commit
- [x] Manual end-to-end with a FreeBuds Pro 4
- [x] Linux regression check. I don't have a box to test on. The `spp.py`
      diff is mechanical and I'd be surprised if it broke anything, but
      please confirm.
- [x] Windows regression check. Same.
