### PR TITLE
Add FreeBuds Pro 5 support and fix SPP packet parsing for large responses

### DIFF
--- a/openfreebuds/driver/constants.py
+++ b/openfreebuds/driver/constants.py
@@ -12,6 +12,7 @@ DEVICE_TO_DRIVER_MAP = {
     "HUAWEI FreeBuds Pro 2": OfbDriverHuaweiPro2,
     "HUAWEI FreeBuds Pro 3": OfbDriverHuaweiPro3,
     "HUAWEI FreeBuds Pro 4": OfbDriverHuaweiPro3,
+    "HUAWEI FreeBuds Pro 5": OfbDriverHuaweiPro5,
     "HUAWEI FreeClip": OfbDriverHuaweiPro3,
     "HUAWEI FreeBuds SE": OfbDriverHuaweiSe,
     "HUAWEI FreeBuds SE 2": OfbDriverHuaweiSe2,

--- a/openfreebuds/driver/huawei/driver/generic.py
+++ b/openfreebuds/driver/huawei/driver/generic.py
@@ -117,8 +117,8 @@ class OfbDriverHuaweiGeneric(OfbDriverSppGeneric):
         if len(heading) == 0:
             log.debug("Got empty package, seems like socked is closed")
             raise ConnectionResetError
-        if heading[0:2] == b"Z\x00":
-            length = heading[2]
+        if heading[0] == 0x5A:
+            length = int.from_bytes(heading[1:3], byteorder="big")
             if length < 4:
                 await reader.read(length)
             else:

--- a/openfreebuds/driver/huawei/driver/per_model/__init__.py
+++ b/openfreebuds/driver/huawei/driver/per_model/__init__.py
@@ -4,6 +4,7 @@ from .buds_6i import OfbDriverHuawei6I
 from .buds_pro import OfbDriverHuaweiPro
 from .buds_pro_2 import OfbDriverHuaweiPro2
 from .buds_pro_3 import OfbDriverHuaweiPro3
+from .buds_pro_5 import OfbDriverHuaweiPro5
 from .buds_se import OfbDriverHuaweiSe
 from .buds_se_2 import OfbDriverHuaweiSe2
 from .buds_se_4 import OfbDriverHuaweiSe4

--- a/openfreebuds/driver/huawei/driver/per_model/buds_pro_5.py
+++ b/openfreebuds/driver/huawei/driver/per_model/buds_pro_5.py
@@ -1,0 +1,29 @@
+from openfreebuds.driver.huawei.driver.generic import OfbDriverHuaweiGeneric
+from openfreebuds.driver.huawei.handler import *
+
+
+class OfbDriverHuaweiPro5(OfbDriverHuaweiGeneric):
+    def __init__(self, address):
+        super().__init__(address)
+        self._spp_service_port = 1
+        self.handlers = [
+            OfbHuaweiInfoHandler(),
+            OfbHuaweiAncHandler(w_cancel_lvl=True, w_cancel_dynamic=True, w_voice_boost=True),
+            OfbHuaweiBatteryHandler(),
+            OfnHuaweiSoundQualityPreferenceHandler(),
+            OfbHuaweiEqualizerPresetHandler(w_presets={
+                5: "default",
+                1: "hardbass",
+                2: "treble",
+                9: "voice",
+            }),
+            OfbHuaweiConfigAutoPauseHandler(),
+            OfbHuaweiDualConnectHandler(),
+            OfbHuaweiStateInEarHandler(),
+            OfbHuaweiVoiceLanguageHandler(),
+            OfbHuaweiActionDoubleTapHandler(),
+            OfbHuaweiActionLongTapSplitHandler(w_right=True),
+            OfbHuaweiActionSwipeGestureHandler(),
+            OfbHuaweiLowLatencyPreferenceHandler(),
+            OfbHuaweiEqualizerPresetHandler(w_custom=True),
+        ]


### PR DESCRIPTION
## Summary

- **Fix SPP packet length parsing**: `__recv_pacakge` read the packet length from a single byte (`heading[2]`) instead of two bytes big-endian (`heading[1:3]`). This truncated any response larger than 255 bytes, corrupting the receive buffer and causing all subsequent packets to fail. The header check also assumed `heading[1]` was always `0x00`, but it is the high byte of the length field.
- **Add HUAWEI FreeBuds Pro 5 driver**: New driver based on Pro 3, tested with ANC (cancellation levels, voice boost), battery, equalizer presets (with custom support), auto-pause, dual connect, in-ear state, voice language, gestures (double tap, long tap split L/R, swipe), and low latency.

## Details

The FreeBuds Pro 5 (Kirin A3 chip) returns a 282-byte device info response to command `0x0107`. The old single-byte length read capped at 255, so the response was truncated and the stream desynchronized — causing `device_info` init to timeout after 5 retries and leaving the info page empty.

This bug potentially affects any device whose SPP response exceeds 255 bytes, not just the Pro 5.

## Test plan

- [x] Verified device info loads correctly (hardware version, firmware, serial number, model, per-earphone SNs)
- [x] Verified battery, ANC, equalizer, dual connect, gestures all initialize successfully
- [x] Confirmed no regression on packet parsing for smaller responses (all other handlers init fine)