### PR TITLE
Add Huawei AI Life-inspired battery popup overlay

### DIFF
--- a/openfreebuds_qt/app/module/ui_settings.py
+++ b/openfreebuds_qt/app/module/ui_settings.py
@@ -66,6 +66,11 @@ class OfbQtUiSettingsModule(Ui_OfbQtUiSettingsModule, OfbQtCommonModule):
         with blocked_signals(self.tray_dc_toggle):
             self.tray_dc_toggle.setChecked(self.config.get("ui", "tray_show_dual_connect", False))
 
+        with blocked_signals(self.low_battery_overlay_toggle):
+            self.low_battery_overlay_toggle.setChecked(self.config.get("ui", "low_battery_overlay", True))
+
+        self.low_battery_overlay_test_button.setVisible(bool(getattr(self.ctx.args, "virtual_device", None)))
+
     async def update_ui(self, event: OfbCoreEvent):
         if not event.kind_match(OfbEventKind.QT_SETTINGS_CHANGED):
             return
@@ -104,6 +109,15 @@ class OfbQtUiSettingsModule(Ui_OfbQtUiSettingsModule, OfbQtCommonModule):
         self.config.set("ui", "tray_show_dual_connect", value)
         self.config.save()
         await self.ofb.send_message(OfbEventKind.QT_SETTINGS_CHANGED)
+
+    @asyncSlot(bool)
+    async def on_low_battery_overlay_toggle(self, value: bool):
+        self.config.set("ui", "low_battery_overlay", value)
+        self.config.save()
+
+    @asyncSlot()
+    async def on_low_battery_overlay_test(self):
+        await self.ctx.tray.show_low_battery_overlay_preview()
 
     @asyncSlot(int)
     async def on_language_choose(self, index: int):

--- a/openfreebuds_qt/app/module/ui_settings.py
+++ b/openfreebuds_qt/app/module/ui_settings.py
@@ -69,6 +69,11 @@ class OfbQtUiSettingsModule(Ui_OfbQtUiSettingsModule, OfbQtCommonModule):
         with blocked_signals(self.low_battery_overlay_toggle):
             self.low_battery_overlay_toggle.setChecked(self.config.get("ui", "low_battery_overlay", True))
 
+        with blocked_signals(self.battery_overlay_on_connect_toggle):
+            self.battery_overlay_on_connect_toggle.setChecked(
+                self.config.get("ui", "battery_overlay_on_connect", False)
+            )
+
         self.low_battery_overlay_test_button.setVisible(bool(getattr(self.ctx.args, "virtual_device", None)))
 
     async def update_ui(self, event: OfbCoreEvent):
@@ -113,6 +118,11 @@ class OfbQtUiSettingsModule(Ui_OfbQtUiSettingsModule, OfbQtCommonModule):
     @asyncSlot(bool)
     async def on_low_battery_overlay_toggle(self, value: bool):
         self.config.set("ui", "low_battery_overlay", value)
+        self.config.save()
+
+    @asyncSlot(bool)
+    async def on_battery_overlay_on_connect_toggle(self, value: bool):
+        self.config.set("ui", "battery_overlay_on_connect", value)
         self.config.save()
 
     @asyncSlot()

--- a/openfreebuds_qt/app/widget/low_battery_overlay.py
+++ b/openfreebuds_qt/app/widget/low_battery_overlay.py
@@ -1,0 +1,172 @@
+from PyQt6.QtCore import QEasingCurve, QPoint, QPropertyAnimation, Qt, QTimer
+from PyQt6.QtGui import QGuiApplication
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout, QWidget
+
+from openfreebuds_qt.utils import get_img_colored
+
+
+class LowBatteryOverlay(QWidget):
+    DISPLAY_MS = 3000
+    SHOW_DURATION_MS = 230
+    HIDE_DURATION_MS = 180
+    SLIDE_OFFSET = 22
+    TOP_MARGIN = 18
+    ICON_COLOR = (244, 246, 248, 255)
+    WIDTH_BY_ITEM_COUNT = {
+        1: 148,
+        2: 182,
+        3: 214,
+    }
+
+    def __init__(self, device_name: str, battery: dict, threshold: int):
+        super().__init__(None)
+
+        del threshold
+        self._show_animation = None
+        self._hide_animation = None
+        self._hide_timer = QTimer(self)
+        self._hide_timer.setSingleShot(True)
+        self._hide_timer.timeout.connect(self.hide_overlay)
+
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.Tool
+            | Qt.WindowType.WindowStaysOnTopHint
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+
+        frame = QFrame(self)
+        frame.setObjectName("lowBatteryOverlayFrame")
+        frame.setStyleSheet("""
+            #lowBatteryOverlayFrame {
+                background-color: #17191d;
+                border: 1px solid rgba(255, 255, 255, 38);
+                border-radius: 14px;
+            }
+            QLabel {
+                color: #f4f6f8;
+                background: transparent;
+            }
+            QLabel[role="title"] {
+                font-size: 12px;
+                font-weight: 600;
+            }
+            QLabel[role="value"] {
+                font-size: 13px;
+                font-weight: 600;
+            }
+        """)
+        root.addWidget(frame)
+
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(14, 10, 14, 10)
+        layout.setSpacing(7)
+
+        title = QLabel(device_name or "OpenFreebuds", frame)
+        title.setProperty("role", "title")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title.setMaximumHeight(18)
+        layout.addWidget(title)
+
+        battery_layout = QHBoxLayout()
+        battery_layout.setSpacing(12)
+        battery_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addLayout(battery_layout)
+
+        battery_items = self._battery_items(battery)
+        for key, value in battery_items:
+            item = QHBoxLayout()
+            item.setSpacing(4)
+            item.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+            icon = QLabel(frame)
+            icon.setFixedSize(18, 18)
+            icon_pixmap = self._battery_icon(key)
+            if icon_pixmap is not None:
+                icon.setPixmap(icon_pixmap)
+            item.addWidget(icon)
+
+            value_label = QLabel(f"{value}%", frame)
+            value_label.setProperty("role", "value")
+            value_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            item.addWidget(value_label)
+
+            battery_layout.addLayout(item)
+
+        self.setFixedWidth(self.WIDTH_BY_ITEM_COUNT.get(len(battery_items), 214))
+        self.adjustSize()
+
+    def show_overlay(self):
+        screen = QGuiApplication.primaryScreen()
+        geometry = screen.availableGeometry()
+        x = geometry.x() + (geometry.width() - self.width()) // 2
+        visible_y = geometry.y() + self.TOP_MARGIN
+        hidden_y = visible_y - self.height() - self.SLIDE_OFFSET
+
+        self.move(x, hidden_y)
+        self.show()
+        self.raise_()
+
+        self._show_animation = QPropertyAnimation(self, b"pos", self)
+        self._show_animation.setDuration(self.SHOW_DURATION_MS)
+        self._show_animation.setStartValue(QPoint(x, hidden_y))
+        self._show_animation.setEndValue(QPoint(x, visible_y))
+        self._show_animation.setEasingCurve(QEasingCurve.Type.OutCubic)
+        self._show_animation.finished.connect(lambda: self._hide_timer.start(self.DISPLAY_MS))
+        self._show_animation.start()
+
+    def hide_overlay(self):
+        if not self.isVisible():
+            return
+
+        self._hide_timer.stop()
+        end_pos = QPoint(self.x(), self.y() - self.height() - self.SLIDE_OFFSET)
+        self._hide_animation = QPropertyAnimation(self, b"pos", self)
+        self._hide_animation.setDuration(self.HIDE_DURATION_MS)
+        self._hide_animation.setStartValue(self.pos())
+        self._hide_animation.setEndValue(end_pos)
+        self._hide_animation.setEasingCurve(QEasingCurve.Type.InCubic)
+        self._hide_animation.finished.connect(self.close)
+        self._hide_animation.start()
+
+    def closeEvent(self, event):
+        self._hide_timer.stop()
+        if self._show_animation is not None:
+            self._show_animation.stop()
+        if self._hide_animation is not None:
+            self._hide_animation.stop()
+        event.accept()
+
+    def _battery_items(self, battery: dict):
+        if all(key in battery for key in ("left", "right", "case")):
+            return [
+                ("left", battery["left"]),
+                ("right", battery["right"]),
+                ("case", battery["case"]),
+            ]
+
+        rows = []
+        for key in ("left", "right", "case", "global"):
+            if key in battery:
+                rows.append((key, battery[key]))
+
+        return rows or [("global", "--")]
+
+    @classmethod
+    def _battery_icon(cls, key: str):
+        icon_name = {
+            "left": "batt_l",
+            "right": "batt_r",
+            "case": "batt_c",
+            "global": "batt_c",
+        }.get(key, "batt_c")
+
+        try:
+            return get_img_colored(icon_name, cls.ICON_COLOR, "icon/main_window", (18, 18))
+        except Exception:
+            return None

--- a/openfreebuds_qt/app/widget/low_battery_overlay.py
+++ b/openfreebuds_qt/app/widget/low_battery_overlay.py
@@ -12,6 +12,9 @@ class LowBatteryOverlay(QWidget):
     SLIDE_OFFSET = 22
     TOP_MARGIN = 18
     ICON_COLOR = (244, 246, 248, 255)
+    VALUE_COLOR_DEFAULT = "#f4f6f8"
+    VALUE_COLOR_WARNING = "#ffb454"
+    VALUE_COLOR_CRITICAL = "#ff5f57"
     WIDTH_BY_ITEM_COUNT = {
         1: 148,
         2: 182,
@@ -94,6 +97,7 @@ class LowBatteryOverlay(QWidget):
             value_label = QLabel(f"{value}%", frame)
             value_label.setProperty("role", "value")
             value_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            value_label.setStyleSheet(f"color: {self._battery_value_color(key, value)};")
             item.addWidget(value_label)
 
             battery_layout.addLayout(item)
@@ -170,3 +174,13 @@ class LowBatteryOverlay(QWidget):
             return get_img_colored(icon_name, cls.ICON_COLOR, "icon/main_window", (18, 18))
         except Exception:
             return None
+
+    @classmethod
+    def _battery_value_color(cls, key: str, value):
+        if key not in ("left", "right") or isinstance(value, bool) or not isinstance(value, int):
+            return cls.VALUE_COLOR_DEFAULT
+        if value <= 10:
+            return cls.VALUE_COLOR_CRITICAL
+        if value <= 20:
+            return cls.VALUE_COLOR_WARNING
+        return cls.VALUE_COLOR_DEFAULT

--- a/openfreebuds_qt/assets/i18n/de.ts
+++ b/openfreebuds_qt/assets/i18n/de.ts
@@ -1133,6 +1133,21 @@
         <source>Show equalizer preset switcher in menu (if available)</source>
         <translation>Zeige Equalizerprofil im Menü (falls verfügbar)</translation>
     </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Battery alerts</source>
+        <translation>Akkuwarnungen</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show low battery popup</source>
+        <translation>Popup bei niedrigem Akkustand anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Preview low battery popup</source>
+        <translation>Vorschau des Popups bei niedrigem Akkustand</translation>
+    </message>
 </context><context>
     <name>OfbTrayIcon</name>
     <message>

--- a/openfreebuds_qt/assets/i18n/de.ts
+++ b/openfreebuds_qt/assets/i18n/de.ts
@@ -1145,6 +1145,11 @@
     </message>
     <message>
         <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show battery popup when device connects</source>
+        <translation>Akku-Popup anzeigen, wenn ein Gerät verbunden wird</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
         <source>Preview low battery popup</source>
         <translation>Vorschau des Popups bei niedrigem Akkustand</translation>
     </message>

--- a/openfreebuds_qt/assets/i18n/en.ts
+++ b/openfreebuds_qt/assets/i18n/en.ts
@@ -1130,6 +1130,21 @@
         <source>Show equalizer preset switcher in menu (if available)</source>
         <translation type="unfinished" />
     </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Battery alerts</source>
+        <translation>Battery alerts</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show low battery popup</source>
+        <translation>Show low battery popup</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Preview low battery popup</source>
+        <translation>Preview low battery popup</translation>
+    </message>
 </context><context>
     <name>OfbTrayIcon</name>
     <message>

--- a/openfreebuds_qt/assets/i18n/en.ts
+++ b/openfreebuds_qt/assets/i18n/en.ts
@@ -1142,6 +1142,11 @@
     </message>
     <message>
         <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show battery popup when device connects</source>
+        <translation>Show battery popup when device connects</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
         <source>Preview low battery popup</source>
         <translation>Preview low battery popup</translation>
     </message>

--- a/openfreebuds_qt/assets/i18n/es.ts
+++ b/openfreebuds_qt/assets/i18n/es.ts
@@ -1130,6 +1130,21 @@
         <source>Show equalizer preset switcher in menu (if available)</source>
         <translation>Mostrar los perfiles del equalizador en el menu (si está disponible)</translation>
     </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Battery alerts</source>
+        <translation>Alertas de batería</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show low battery popup</source>
+        <translation>Mostrar ventana emergente de batería baja</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Preview low battery popup</source>
+        <translation>Vista previa de la ventana emergente de batería baja</translation>
+    </message>
 </context><context>
     <name>OfbTrayIcon</name>
     <message>

--- a/openfreebuds_qt/assets/i18n/es.ts
+++ b/openfreebuds_qt/assets/i18n/es.ts
@@ -1142,6 +1142,11 @@
     </message>
     <message>
         <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show battery popup when device connects</source>
+        <translation>Mostrar ventana emergente de batería al conectar el dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
         <source>Preview low battery popup</source>
         <translation>Vista previa de la ventana emergente de batería baja</translation>
     </message>

--- a/openfreebuds_qt/assets/i18n/pt-BR.ts
+++ b/openfreebuds_qt/assets/i18n/pt-BR.ts
@@ -1143,6 +1143,11 @@
     </message>
     <message>
         <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show battery popup when device connects</source>
+        <translation>Mostrar popup de bateria ao conectar o dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
         <source>Preview low battery popup</source>
         <translation>Visualizar pop-up de bateria fraca</translation>
     </message>

--- a/openfreebuds_qt/assets/i18n/pt-BR.ts
+++ b/openfreebuds_qt/assets/i18n/pt-BR.ts
@@ -1131,6 +1131,21 @@
         <source>Show equalizer preset switcher in menu (if available)</source>
         <translation>Mostrar alternador de predefinições do equalizador no menu (se disponível)</translation>
     </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Battery alerts</source>
+        <translation>Alertas de bateria</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show low battery popup</source>
+        <translation>Mostrar pop-up de bateria fraca</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Preview low battery popup</source>
+        <translation>Visualizar pop-up de bateria fraca</translation>
+    </message>
 </context><context>
     <name>OfbTrayIcon</name>
     <message>

--- a/openfreebuds_qt/assets/i18n/ru.ts
+++ b/openfreebuds_qt/assets/i18n/ru.ts
@@ -1143,6 +1143,11 @@
     </message>
     <message>
         <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show battery popup when device connects</source>
+        <translation>Показывать всплывающее окно батареи при подключении устройства</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
         <source>Preview low battery popup</source>
         <translation>Предпросмотр всплывающего окна о низком заряде</translation>
     </message>

--- a/openfreebuds_qt/assets/i18n/ru.ts
+++ b/openfreebuds_qt/assets/i18n/ru.ts
@@ -1131,6 +1131,21 @@
         <source>Show equalizer preset switcher in menu (if available)</source>
         <translation>Показывать опции эквалайзера в меню (если доступно)</translation>
     </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Battery alerts</source>
+        <translation>Уведомления о заряде</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show low battery popup</source>
+        <translation>Показывать всплывающее окно при низком заряде</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Preview low battery popup</source>
+        <translation>Предпросмотр всплывающего окна о низком заряде</translation>
+    </message>
 </context><context>
     <name>OfbTrayIcon</name>
     <message>

--- a/openfreebuds_qt/assets/i18n/tr_TR.ts
+++ b/openfreebuds_qt/assets/i18n/tr_TR.ts
@@ -1142,6 +1142,11 @@
     </message>
     <message>
         <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show battery popup when device connects</source>
+        <translation>Cihaz bağlanınca pil açılır penceresini göster</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
         <source>Preview low battery popup</source>
         <translation>Düşük pil açılır penceresini önizle</translation>
     </message>

--- a/openfreebuds_qt/assets/i18n/tr_TR.ts
+++ b/openfreebuds_qt/assets/i18n/tr_TR.ts
@@ -1130,6 +1130,21 @@
         <source>Show equalizer preset switcher in menu (if available)</source>
         <translation>Menüde ekolayzır ön ayarını göster (varsa)</translation>
     </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Battery alerts</source>
+        <translation>Pil uyarıları</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show low battery popup</source>
+        <translation>Düşük pil açılır penceresini göster</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Preview low battery popup</source>
+        <translation>Düşük pil açılır penceresini önizle</translation>
+    </message>
 </context><context>
     <name>OfbTrayIcon</name>
     <message>

--- a/openfreebuds_qt/assets/i18n/zh-CN.ts
+++ b/openfreebuds_qt/assets/i18n/zh-CN.ts
@@ -1142,6 +1142,11 @@
     </message>
     <message>
         <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show battery popup when device connects</source>
+        <translation>设备连接时显示电量弹窗</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
         <source>Preview low battery popup</source>
         <translation>预览低电量弹窗</translation>
     </message>

--- a/openfreebuds_qt/assets/i18n/zh-CN.ts
+++ b/openfreebuds_qt/assets/i18n/zh-CN.ts
@@ -1130,6 +1130,21 @@
         <source>Show equalizer preset switcher in menu (if available)</source>
         <translation>在菜单中显示均衡器预设切换器（如果可用）</translation>
     </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Battery alerts</source>
+        <translation>电量提醒</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Show low battery popup</source>
+        <translation>显示低电量弹窗</translation>
+    </message>
+    <message>
+        <location filename="../../designer/ui_settings.ui" line="0" />
+        <source>Preview low battery popup</source>
+        <translation>预览低电量弹窗</translation>
+    </message>
 </context><context>
     <name>OfbTrayIcon</name>
     <message>

--- a/openfreebuds_qt/designer/main_window.ui
+++ b/openfreebuds_qt/designer/main_window.ui
@@ -128,7 +128,7 @@
           <property name="minimumSize">
            <size>
             <width>0</width>
-            <height>24</height>
+            <height>32</height>
            </size>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_8">
@@ -139,7 +139,7 @@
             <number>4</number>
            </property>
            <property name="rightMargin">
-            <number>4</number>
+            <number>24</number>
            </property>
            <property name="bottomMargin">
             <number>4</number>
@@ -181,14 +181,14 @@
              </property>
              <property name="minimumSize">
               <size>
-               <width>24</width>
-               <height>24</height>
+               <width>22</width>
+               <height>22</height>
               </size>
              </property>
              <property name="maximumSize">
               <size>
-               <width>24</width>
-               <height>24</height>
+               <width>22</width>
+               <height>22</height>
               </size>
              </property>
              <property name="styleSheet">
@@ -199,8 +199,8 @@
              </property>
              <property name="iconSize">
               <size>
-               <width>24</width>
-               <height>24</height>
+               <width>18</width>
+               <height>18</height>
               </size>
              </property>
              <property name="flat">

--- a/openfreebuds_qt/designer/ui_settings.ui
+++ b/openfreebuds_qt/designer/ui_settings.ui
@@ -166,6 +166,13 @@
        </widget>
       </item>
       <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="battery_overlay_on_connect_toggle">
+        <property name="text">
+         <string>Show battery popup when device connects</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
        <widget class="QPushButton" name="low_battery_overlay_test_button">
         <property name="text">
          <string>Preview low battery popup</string>
@@ -337,6 +344,22 @@
    </hints>
   </connection>
   <connection>
+   <sender>battery_overlay_on_connect_toggle</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>OfbQtUiSettingsModule</receiver>
+   <slot>on_battery_overlay_on_connect_toggle(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>247</x>
+     <y>352</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>247</x>
+     <y>261</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>low_battery_overlay_test_button</sender>
    <signal>clicked()</signal>
    <receiver>OfbQtUiSettingsModule</receiver>
@@ -363,6 +386,7 @@
   <slot>on_updater_policy_choose(int)</slot>
   <slot>on_background_toggle()</slot>
   <slot>on_low_battery_overlay_toggle(bool)</slot>
+  <slot>on_battery_overlay_on_connect_toggle(bool)</slot>
   <slot>on_low_battery_overlay_test()</slot>
  </slots>
 </ui>

--- a/openfreebuds_qt/designer/ui_settings.ui
+++ b/openfreebuds_qt/designer/ui_settings.ui
@@ -153,6 +153,29 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="low_battery_overlay_group">
+     <property name="title">
+      <string>Battery alerts</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="low_battery_overlay_toggle">
+        <property name="text">
+         <string>Show low battery popup</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QPushButton" name="low_battery_overlay_test_button">
+        <property name="text">
+         <string>Preview low battery popup</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>
@@ -297,6 +320,38 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>low_battery_overlay_toggle</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>OfbQtUiSettingsModule</receiver>
+   <slot>on_low_battery_overlay_toggle(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>247</x>
+     <y>323</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>247</x>
+     <y>261</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>low_battery_overlay_test_button</sender>
+   <signal>clicked()</signal>
+   <receiver>OfbQtUiSettingsModule</receiver>
+   <slot>on_low_battery_overlay_test()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>247</x>
+     <y>352</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>247</x>
+     <y>261</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>on_tray_eq_toggle(bool)</slot>
@@ -307,5 +362,7 @@
   <slot>on_autostart_toggle(bool)</slot>
   <slot>on_updater_policy_choose(int)</slot>
   <slot>on_background_toggle()</slot>
+  <slot>on_low_battery_overlay_toggle(bool)</slot>
+  <slot>on_low_battery_overlay_test()</slot>
  </slots>
 </ui>

--- a/openfreebuds_qt/tray/main.py
+++ b/openfreebuds_qt/tray/main.py
@@ -184,7 +184,7 @@ class OfbTrayIcon(IOfbTrayIcon):
             device_name,
             {
                 "left": 10,
-                "right": 18,
+                "right": 20,
                 "case": 42,
             },
             10,

--- a/openfreebuds_qt/tray/main.py
+++ b/openfreebuds_qt/tray/main.py
@@ -47,6 +47,8 @@ class OfbTrayIcon(IOfbTrayIcon):
             20: False,
         }
         self._low_battery_device_addr = ""
+        self._battery_summary_device_addr = ""
+        self._battery_summary_overlay_shown = False
 
         self.menu = OfbQtTrayMenu(self, self.ctx, self.ofb)
         self.setContextMenu(self.menu)
@@ -103,10 +105,15 @@ class OfbTrayIcon(IOfbTrayIcon):
         else:
             self.setToolTip("OpenFreebuds")
 
-        if state == IOpenFreebuds.STATE_CONNECTED and event.is_changed("battery", ""):
-            await self._check_low_battery_overlay()
-        elif state != IOpenFreebuds.STATE_CONNECTED:
+        if state == IOpenFreebuds.STATE_CONNECTED:
+            summary_shown = False
+            if event.kind_match(OfbEventKind.STATE_CHANGED) or event.is_changed("battery", ""):
+                summary_shown = await self._check_battery_summary_overlay()
+            if event.is_changed("battery", "") and not summary_shown:
+                await self._check_low_battery_overlay()
+        else:
             self._reset_low_battery_alerts()
+            self._reset_battery_summary_overlay()
 
         await self.menu.on_core_event(event, state)
 
@@ -120,6 +127,26 @@ class OfbTrayIcon(IOfbTrayIcon):
             self._last_tooltip = f"{device_name}: {battery}%"
 
         return self._last_tooltip
+
+    async def _check_battery_summary_overlay(self):
+        if not self.config.get("ui", "battery_overlay_on_connect", False):
+            return False
+
+        battery = await self.ofb.get_property("battery")
+        if battery is None:
+            return False
+
+        device_name, device_addr = await self.ofb.get_device_tags()
+        if device_addr != self._battery_summary_device_addr:
+            self._battery_summary_device_addr = device_addr
+            self._battery_summary_overlay_shown = False
+
+        if self._battery_summary_overlay_shown:
+            return False
+
+        self._battery_summary_overlay_shown = True
+        self._show_low_battery_overlay(device_name, battery, 0)
+        return True
 
     async def _check_low_battery_overlay(self):
         if not self.config.get("ui", "low_battery_overlay", True):
@@ -193,6 +220,10 @@ class OfbTrayIcon(IOfbTrayIcon):
     def _reset_low_battery_alerts(self):
         self._low_battery_alert_shown[10] = False
         self._low_battery_alert_shown[20] = False
+
+    def _reset_battery_summary_overlay(self):
+        self._battery_summary_device_addr = ""
+        self._battery_summary_overlay_shown = False
 
     @staticmethod
     def _get_min_battery_level(battery: dict):

--- a/openfreebuds_qt/tray/main.py
+++ b/openfreebuds_qt/tray/main.py
@@ -15,6 +15,11 @@ from openfreebuds_qt.generic import IOfbTrayIcon
 from openfreebuds_qt.tray.menu import OfbQtTrayMenu
 from openfreebuds_qt.utils import OfbCoreEvent, qt_error_handler, create_tray_icon
 
+try:
+    from openfreebuds_qt.app.widget.low_battery_overlay import LowBatteryOverlay
+except ImportError:
+    LowBatteryOverlay = None
+
 log = create_logger("OfbTrayIcon")
 
 
@@ -36,6 +41,12 @@ class OfbTrayIcon(IOfbTrayIcon):
         self.config = OfbQtConfigParser.get_instance()
 
         self.ui_update_task: Optional[asyncio.Task] = None
+        self._low_battery_overlay = None
+        self._low_battery_alert_shown = {
+            10: False,
+            20: False,
+        }
+        self._low_battery_device_addr = ""
 
         self.menu = OfbQtTrayMenu(self, self.ctx, self.ofb)
         self.setContextMenu(self.menu)
@@ -92,6 +103,11 @@ class OfbTrayIcon(IOfbTrayIcon):
         else:
             self.setToolTip("OpenFreebuds")
 
+        if state == IOpenFreebuds.STATE_CONNECTED and event.is_changed("battery", ""):
+            await self._check_low_battery_overlay()
+        elif state != IOpenFreebuds.STATE_CONNECTED:
+            self._reset_low_battery_alerts()
+
         await self.menu.on_core_event(event, state)
 
     async def _get_tooltip_text(self, event: OfbCoreEvent):
@@ -104,6 +120,95 @@ class OfbTrayIcon(IOfbTrayIcon):
             self._last_tooltip = f"{device_name}: {battery}%"
 
         return self._last_tooltip
+
+    async def _check_low_battery_overlay(self):
+        if not self.config.get("ui", "low_battery_overlay", True):
+            return
+
+        battery = await self.ofb.get_property("battery")
+        if battery is None:
+            return
+
+        device_name, device_addr = await self.ofb.get_device_tags()
+        if device_addr != self._low_battery_device_addr:
+            self._low_battery_device_addr = device_addr
+            self._reset_low_battery_alerts()
+
+        min_battery = self._get_min_battery_level(battery)
+        if min_battery is None:
+            return
+
+        if min_battery > 25:
+            self._low_battery_alert_shown[20] = False
+        if min_battery > 15:
+            self._low_battery_alert_shown[10] = False
+
+        threshold = None
+        if min_battery <= 10:
+            threshold = 10
+        elif min_battery <= 20:
+            threshold = 20
+
+        if threshold is None or self._low_battery_alert_shown[threshold]:
+            return
+
+        self._low_battery_alert_shown[threshold] = True
+        self._show_low_battery_overlay(device_name, battery, threshold)
+
+    def _show_low_battery_overlay(self, device_name: str, battery: dict, threshold: int):
+        if LowBatteryOverlay is None:
+            log.warning("Low battery overlay is not available")
+            return
+
+        try:
+            if self._low_battery_overlay is not None:
+                self._low_battery_overlay.close()
+
+            overlay = LowBatteryOverlay(device_name, battery, threshold)
+            overlay.destroyed.connect(lambda _=None, current=overlay: self._on_low_battery_overlay_destroyed(current))
+            self._low_battery_overlay = overlay
+            overlay.show_overlay()
+        except Exception:
+            log.exception("Failed to show low battery overlay")
+
+    def _on_low_battery_overlay_destroyed(self, overlay):
+        if self._low_battery_overlay is overlay:
+            self._low_battery_overlay = None
+
+    async def show_low_battery_overlay_preview(self):
+        if await self.ofb.get_state() != IOpenFreebuds.STATE_CONNECTED:
+            return
+
+        device_name, _ = await self.ofb.get_device_tags()
+        self._show_low_battery_overlay(
+            device_name,
+            {
+                "left": 10,
+                "right": 18,
+                "case": 42,
+            },
+            10,
+        )
+
+    def _reset_low_battery_alerts(self):
+        self._low_battery_alert_shown[10] = False
+        self._low_battery_alert_shown[20] = False
+
+    @staticmethod
+    def _get_min_battery_level(battery: dict):
+        levels = []
+        for key in ("left", "right", "case", "global"):
+            value = battery.get(key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, int):
+                levels.append(value)
+            elif isinstance(value, str) and value.isdigit():
+                levels.append(int(value))
+
+        if not levels:
+            return None
+        return min(levels)
 
     async def _update_loop(self):
         """


### PR DESCRIPTION
## Summary

This PR adds a Huawei AI Life-inspired battery popup overlay for OpenFreebuds.

I missed the familiar battery popup experience from Huawei phones on desktop, so this adds a lightweight custom PyQt overlay instead of relying on native system notifications. The popup provides a more recognizable battery status experience for Huawei FreeBuds users on desktop environments.

The overlay can now be used in two ways:

- show low battery alerts when the minimum battery level reaches 20% and 10%
- optionally show the current battery status once when a device connects

The left and right earbud battery percentages are highlighted when low:
- 20% or below: orange
- 10% or below: red

The case battery value remains neutral.

## Changes

- Added a custom frameless, always-on-top PyQt battery overlay
- Added low battery popup logic with 20% and 10% thresholds
- Added a separate setting to show the battery popup when a device connects
- Added a virtual-device-only preview button for testing the popup
- Added UI settings and translations for the new options
- Adjusted sidebar header spacing around the extra options button

## Testing

This is my first PR to OpenFreebuds, so I tested it carefully before submitting.

Tested on:

- Windows 11 with a real device
- Windows 11 with virtual device mode
- Linux Mint with virtual device mode

Commands used:

```bash
python -m pdm run python -m pytest
python -m pdm run python -m openfreebuds_qt --virtual-device huawei_5i --settings
```

Result:

```text
8 passed
```