### PR TITLE
[model] Add HUAWEI FreeBuds 3 support & macOS SDP fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Device compatibility
 See device page to get information about supported features.
 If your device isn't listed here, you could try to use it with profile for other model.
 
+- [HUAWEI FreeBuds 3](./docs/devices/HUAWEI_FreeBuds_3.md)
 - [HUAWEI FreeBuds 4i](./docs/devices/HUAWEI_FreeBuds_4i.md)
   - **HONOR Earbuds 2 / 2 SE / 2 Lite** is same
 - [HUAWEI FreeBuds 5i](./docs/devices/HUAWEI_FreeBuds_5i.md)

--- a/docs/devices/HUAWEI_FreeBuds_3.md
+++ b/docs/devices/HUAWEI_FreeBuds_3.md
@@ -1,0 +1,15 @@
+# HUAWEI FreeBuds 3
+
+Protocol: Huawei SPP, port 1
+
+## Features
+
+- Fetch device information and battery level: ✅
+- Fetch in-ear status: ✅
+- Set double-tap action: ✅
+- Change voice language: ✅
+  - English, Chinese
+
+## Not planned features
+
+- Firmware update

--- a/openfreebuds/driver/constants.py
+++ b/openfreebuds/driver/constants.py
@@ -5,6 +5,8 @@ DEVICE_TO_DRIVER_MAP = {
     "HONOR Earbuds 2": OfbDriverHuawei4I,
     "HONOR Earbuds 2 SE": OfbDriverHuawei4I,
     "HONOR Earbuds 2 Lite": OfbDriverHuawei4I,
+    "HUAWEI FreeBuds 3": OfbDriverHuawei3,
+    "FreeBuds 3": OfbDriverHuawei3,
     "HUAWEI FreeBuds 4i": OfbDriverHuawei4I,
     "HUAWEI FreeBuds 5i": OfbDriverHuawei5I,
     "HUAWEI FreeBuds 6i": OfbDriverHuawei6I,

--- a/openfreebuds/driver/huawei/driver/per_model/__init__.py
+++ b/openfreebuds/driver/huawei/driver/per_model/__init__.py
@@ -1,3 +1,4 @@
+from .buds_3 import OfbDriverHuawei3
 from .buds_4i import OfbDriverHuawei4I
 from .buds_5i import OfbDriverHuawei5I
 from .buds_6i import OfbDriverHuawei6I

--- a/openfreebuds/driver/huawei/driver/per_model/buds_3.py
+++ b/openfreebuds/driver/huawei/driver/per_model/buds_3.py
@@ -1,0 +1,28 @@
+from openfreebuds.driver.huawei.driver.generic import OfbDriverHuaweiGeneric
+from openfreebuds.driver.huawei.handler import *
+
+
+FREEBUDS_3_DOUBLE_TAP_OPTIONS = {
+    -1: "tap_action_off",
+    0: "tap_action_assistant",
+    1: "tap_action_pause",
+    3: "tap_action_switch_anc",
+    4: "tap_action_next",
+}
+
+
+class OfbDriverHuawei3(OfbDriverHuaweiGeneric):
+    """
+    HUAWEI FreeBuds 3
+    """
+    def __init__(self, address):
+        super().__init__(address)
+        self._spp_service_port = 1
+        self.handlers = [
+            OfbHuaweiLogsHandler(),
+            OfbHuaweiInfoHandler(),
+            OfbHuaweiStateInEarHandler(),
+            OfbHuaweiBatteryHandler(),
+            OfbHuaweiActionDoubleTapHandler(options_map=FREEBUDS_3_DOUBLE_TAP_OPTIONS),
+            OfbHuaweiVoiceLanguageHandler(),
+        ]

--- a/openfreebuds/driver/huawei/handler/abstract/multi_tap.py
+++ b/openfreebuds/driver/huawei/handler/abstract/multi_tap.py
@@ -6,13 +6,16 @@ from openfreebuds.utils import reverse_dict
 
 
 class OfbHuaweiAbstractTapActionHandler(OfbDriverHandlerHuawei):
-    def __init__(self, w_in_call=False):
+    def __init__(self, w_in_call=False, options_map: dict[int, str] | None = None):
         self.prop_prefix = ""
         self.cmd_read = b""
         self.cmd_write = b""
 
         self.w_in_call = w_in_call
-        self._options = {
+        self._raw_available_codes: list[int] = []
+        self._left_code: int | None = None
+        self._right_code: int | None = None
+        self._options = dict(options_map) if options_map is not None else {
             -1: "tap_action_off",
             1: "tap_action_pause",
             2: "tap_action_next",
@@ -37,18 +40,23 @@ class OfbHuaweiAbstractTapActionHandler(OfbDriverHandlerHuawei):
         in_call = package.find_param(4)
         available_options = package.find_param(3)
         if len(left) == 1:
-            value = int.from_bytes(left, byteorder="big", signed=True)
+            self._left_code = int.from_bytes(left, byteorder="big", signed=True)
             await self.driver.put_property("action", f"{self.prop_prefix}_left",
-                                           self._options.get(value, value))
+                                           self._options.get(self._left_code, self._left_code))
         if len(right) == 1:
-            value = int.from_bytes(right, byteorder="big", signed=True)
+            self._right_code = int.from_bytes(right, byteorder="big", signed=True)
             await self.driver.put_property("action", f"{self.prop_prefix}_right",
-                                           self._options.get(value, value))
+                                           self._options.get(self._right_code, self._right_code))
         if len(available_options) > 0:
             value = list(struct.unpack(f'{len(available_options)}b', available_options))
+            self._raw_available_codes = value
             out = []
+            seen = set()
             for v in value:
-                out.append(str(v) if v not in self._options else self._options[v])
+                act = self._options.get(v, str(v))
+                if act not in seen:
+                    seen.add(act)
+                    out.append(act)
             await self.driver.put_property("action", f"{self.prop_prefix}_options", ",".join(out))
         if len(in_call) == 1 and self.w_in_call:
             value = int.from_bytes(in_call, byteorder="big", signed=True)
@@ -57,21 +65,39 @@ class OfbHuaweiAbstractTapActionHandler(OfbDriverHandlerHuawei):
             await self.driver.put_property("action", f"{self.prop_prefix}_in_call_options",
                                            ",".join(self._options_call.values()))
 
+    def _resolve_action_code(self, p_options: dict[int, str], value) -> int:
+        if self._raw_available_codes:
+            for code in self._raw_available_codes:
+                if p_options.get(code) == value:
+                    return code
+        for code, act in p_options.items():
+            if act == value:
+                return code
+        if isinstance(value, int):
+            return value
+        try:
+            return int(value)
+        except ValueError:
+            pass
+        raise KeyError(f"Unknown action {value}")
+
     async def set_property(self, group: str, prop: str, value):
         if prop == f"{self.prop_prefix}_left":
+            self._left_code = self._resolve_action_code(self._options, value)
             p_type = 1
-            p_options = self._options
+            code = self._left_code
         elif prop == f"{self.prop_prefix}_right":
+            self._right_code = self._resolve_action_code(self._options, value)
             p_type = 2
-            p_options = self._options
+            code = self._right_code
         elif prop == f"{self.prop_prefix}_in_call":
+            code = self._resolve_action_code(self._options_call, value)
             p_type = 4
-            p_options = self._options_call
         else:
             return
 
         pkg = HuaweiSppPackage.change_rq(self.cmd_write, [
-            (p_type, reverse_dict(p_options)[value]),
+            (p_type, code),
         ])
         await self.driver.send_package(pkg)
         await self.driver.put_property(group, prop, value)

--- a/openfreebuds/driver/huawei/test/test_buds3.py
+++ b/openfreebuds/driver/huawei/test/test_buds3.py
@@ -1,0 +1,58 @@
+import pytest
+
+from openfreebuds.driver.huawei.driver.per_model.buds_3 import OfbDriverHuawei3
+from openfreebuds.driver import DEVICE_TO_DRIVER_MAP, is_device_supported
+
+
+@pytest.mark.asyncio
+async def test_driver_creation():
+    d = OfbDriverHuawei3("D0:05:E4:12:55:09")
+    assert len(d.handlers) > 0
+    assert d._spp_service_port == 1
+
+    handler_ids = [h.handler_id for h in d.handlers]
+    expected_handlers = [
+        "drop_logs",
+        "device_info",
+        "tws_in_ear",
+        "battery",
+        "gesture_double",
+        "voice_language",
+    ]
+    for handler_id in expected_handlers:
+        assert handler_id in handler_ids, f"Missing handler: {handler_id}"
+
+
+@pytest.mark.asyncio
+async def test_buds3_double_tap():
+    from openfreebuds.driver.huawei.driver.per_model.buds_3 import FREEBUDS_3_DOUBLE_TAP_OPTIONS
+    from openfreebuds.driver.huawei.driver.debug import FbDriverHuaweiGenericFixture
+    from openfreebuds.driver.huawei.handler import OfbHuaweiActionDoubleTapHandler
+    from openfreebuds.driver.huawei.package import HuaweiSppPackage
+
+    # FreeBuds 3 traffic dumps: 0120 returns left=0 (assistant), right=3 (switch_anc), options=[0, 1, 3, 4, -1]
+    get_double_tap = HuaweiSppPackage.read_rq(b"\x01\x20", [1, 2])
+    resp_double_tap = HuaweiSppPackage(b"\x01\x20", [(1, b"\x00"), (2, b"\x03"), (3, b"\x00\x01\x03\x04\xff")])
+    set_right_to_next = HuaweiSppPackage.change_rq(b"\x01\x1f", [(2, 4)])
+    resp_right_to_next = HuaweiSppPackage(b"\x01\x1f", [(3, b"\x00")])
+
+    driver = FbDriverHuaweiGenericFixture(
+        handlers=[
+            OfbHuaweiActionDoubleTapHandler(options_map=FREEBUDS_3_DOUBLE_TAP_OPTIONS)
+        ],
+        package_response_model={
+            get_double_tap.to_bytes(): [resp_double_tap.to_bytes()],
+            set_right_to_next.to_bytes(): [resp_right_to_next.to_bytes()],
+        }
+    )
+
+    await driver.start()
+    assert await driver.get_property("action", "double_tap_left") == "tap_action_assistant"
+    assert await driver.get_property("action", "double_tap_right") == "tap_action_switch_anc"
+    assert await driver.get_property("action", "double_tap_options") == "tap_action_assistant,tap_action_pause,tap_action_switch_anc,tap_action_next,tap_action_off"
+
+    # Write right to next track (should resolve to 4)
+    await driver.set_property("action", "double_tap_right", "tap_action_next")
+    assert await driver.get_property("action", "double_tap_right") == "tap_action_next"
+    assert driver.package_log[0] == ('send', set_right_to_next.to_bytes())
+

--- a/openfreebuds_backend/darwin/_sdp.py
+++ b/openfreebuds_backend/darwin/_sdp.py
@@ -110,7 +110,12 @@ def _service_class_uuids(svc):
     scl = attrs.get(_ATTR_SERVICE_CLASS_ID_LIST)
     if scl is None:
         return out
-    for entry in _seq(scl):
+    seq = _seq(scl)
+    if not seq:
+        u = _uuid16(scl)
+        if u is not None:
+            return [u]
+    for entry in seq:
         u = _uuid16(entry)
         if u is not None:
             out.append(u)

--- a/openfreebuds_qt/app/helper/update_widget_helper.py
+++ b/openfreebuds_qt/app/helper/update_widget_helper.py
@@ -29,7 +29,7 @@ class OfbQtUpdateWidgetHelper:
 
     def user_hide(self):
         updater = self.ctx.updater_service.updater
-        if updater is None:
+        if updater is None or updater.release_info is None:
             self.root_widget.setVisible(False)
             return
 


### PR DESCRIPTION
### Summary of changes

1. **HUAWEI FreeBuds 3 Support**:
   - Added `OfbDriverHuawei3` with support for device info, battery levels, in-ear detection, voice prompt language switching, and double-tap gestures.
   - Added dedicated `FREEBUDS_3_DOUBLE_TAP_OPTIONS` mapping without affecting other models.
   - Added unit test suite `test_buds3.py` (all tests passing).
   - Added compatibility documentation `docs/devices/HUAWEI_FreeBuds_3.md` and updated `README.md`.

2. **macOS & UI Fixes**:
   - Fixed `_service_class_uuids` in `openfreebuds_backend/darwin/_sdp.py` to support single UUID element attributes.
   - Fixed `AttributeError` in `update_widget_helper.py` when `updater.release_info` is `None`.

### Verification
- Tested with real HUAWEI FreeBuds 3 hardware on macOS (Apple M2, 26.5.2).
- Verified unit test suite: 12/12 tests passing.