### PR TITLE
Add configurable per-earbud and case battery tray indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,31 @@ Features
 
 - Dynamic system tray icon that shows current active noise cancellation mode and battery level;
 - Tray menu with battery levels and active noise cancellation settings;
+- Optional separate numeric tray icons for the left earbud, right earbud, and charging case;
 - Ability to change voice language (not all devices supported);
 - Device settings dialog, eg. change equalizer preset, gesture actions, etc;
 - Built-in HTTP-server for remote control & scripting;
 - Built-in global hotkeys support (for Windows and Xorg-Linux)
 
 ![Settings preview](docs/preview_1.png)
+
+### Battery tray indicators
+
+Enable **Application → Tray battery → Show battery percentages in the system tray**
+to display each reported earbud/case level as a separate number, without a `%` sign.
+The indicators are disabled by default. Each indicator has independent text and
+background colors, optional transparency, and text size from 50% to 100% of the
+largest size that fits its tray icon. The preview uses sample battery levels;
+changes are saved and applied immediately.
+
+Hover over an indicator to identify the earbud or case. Left-click opens the
+settings window, and right-click opens the existing tray menu. Indicators hide
+when disconnected, disabled, or when their individual battery level is unavailable.
+Devices reporting only an aggregate battery level do not get additional indicators.
+
+The desktop controls tray visibility and ordering. On Windows, indicators may
+initially appear in the hidden-icons (`^`) menu. The application creates them in
+left/right/case order, but cannot force their final position in the Windows tray.
 
 Device compatibility
 ------------------------

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Features
 Enable **Application → Tray battery → Show battery percentages in the system tray**
 to display each reported earbud/case level as a separate number, without a `%` sign.
 The indicators are disabled by default. Each indicator has independent text and
-background colors, optional transparency, and text size from 50% to 100% of the
-largest size that fits its tray icon. The preview uses sample battery levels;
+background colors, optional transparency, Normal/Bold font weight (Bold by default),
+and text size from 50% to 100% of the largest size that fits its tray icon. The preview uses sample battery levels;
 changes are saved and applied immediately.
 
 Hover over an indicator to identify the earbud or case. Left-click opens the

--- a/openfreebuds_qt/app/main.py
+++ b/openfreebuds_qt/app/main.py
@@ -19,6 +19,7 @@ from openfreebuds_qt.app.module import OfbQtAboutModule, OfbQtSoundQualityModule
     OfbQtHotkeysModule, OfbQtGesturesModule, OfbQtDualConnectModule, OfbQtDeviceOtherSettingsModule, \
     OfbQtDeviceInfoModule, OfbQtCommonModule, OfbQtChooseDeviceModule, OfbQtUiSettingsModule, OfbQtAutomationModule
 from openfreebuds_qt.config import ConfigLock, OfbQtConfigParser
+from openfreebuds_qt.app.module.tray_battery import OfbQtTrayBatteryModule
 from openfreebuds_qt.constants import ASSETS_PATH, LINK_RPC_HELP, LINK_WEBSITE_HELP, WIN32_BODY_STYLE
 from openfreebuds_qt.designer.main_window import Ui_OfbMainWindowDesign
 from openfreebuds_qt.generic import IOfbQtApplication, IOfbMainWindow
@@ -78,6 +79,7 @@ class OfbQtMainWindow(Ui_OfbMainWindowDesign, IOfbMainWindow):
         self.tabs.add_section(self.tr("Application"))
         if ConfigLock.owned:
             self._attach_module(self.tr("User interface"), OfbQtUiSettingsModule(self.tabs.root, self.ctx))
+            self._attach_module(self.tr("Tray battery"), OfbQtTrayBatteryModule(self.tabs.root, self.ctx))
             self._attach_module(self.tr("Automation"), OfbQtAutomationModule(self.tabs.root, self.ctx))
         if OfbQtHotkeysModule.available():
             self._attach_module(self.tr("Keyboard shortcuts"), OfbQtHotkeysModule(self.tabs.root, self.ctx))

--- a/openfreebuds_qt/app/module/tray_battery.py
+++ b/openfreebuds_qt/app/module/tray_battery.py
@@ -1,0 +1,129 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QCheckBox, QColorDialog, QComboBox, QSpinBox, QFormLayout,
+    QHBoxLayout, QLabel, QPushButton, QVBoxLayout,
+)
+from qasync import asyncSlot
+
+from openfreebuds import OfbEventKind
+from openfreebuds_qt.app.module.common import OfbQtCommonModule
+from openfreebuds_qt.config import OfbQtConfigParser
+from openfreebuds_qt.tray.battery import battery_style, percentage_icon
+from openfreebuds_qt.utils import blocked_signals
+from openfreebuds_qt.utils.async_dialog import run_dialog_async
+
+
+class OfbQtTrayBatteryModule(OfbQtCommonModule):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.config = OfbQtConfigParser.get_instance()
+        layout = QVBoxLayout(self)
+        self.enabled = QCheckBox(self.tr("Show battery percentages in the system tray"))
+        self.enabled.setChecked(self.config.get("ui", "tray_battery_percentages", False))
+        layout.addWidget(self.enabled)
+        form = QFormLayout()
+        self.component = QComboBox()
+        for label, key in ((self.tr("Left earbud"), "left"), (self.tr("Right earbud"), "right"),
+                           (self.tr("Charging case"), "case")):
+            self.component.addItem(label, key)
+        form.addRow(self.tr("Customize indicator"), self.component)
+        self.text_button = QPushButton()
+        self.background_button = QPushButton()
+        form.addRow(self.tr("Text color"), self.text_button)
+        form.addRow(self.tr("Background color"), self.background_button)
+        self.font_scale = QSpinBox()
+        self.font_scale.setRange(50, 100)
+        self.font_scale.setSuffix("%")
+        self.font_scale.setSingleStep(5)
+        form.addRow(self.tr("Text size (100% = largest that fits)"), self.font_scale)
+        layout.addLayout(form)
+        self.transparent = QCheckBox(self.tr("Transparent background"))
+        layout.addWidget(self.transparent)
+        layout.addWidget(QLabel(self.tr("Preview")))
+        preview = QHBoxLayout()
+        self.previews = []
+        for label, key, level in ((self.tr("Left earbud"), "left", 50), (self.tr("Right earbud"), "right", 65),
+                             (self.tr("Charging case"), "case", 85)):
+            column = QVBoxLayout()
+            icon = QLabel()
+            icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            caption = QLabel(label)
+            caption.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            column.addWidget(icon)
+            column.addWidget(caption)
+            preview.addLayout(column)
+            self.previews.append((icon, key, level))
+        layout.addLayout(preview)
+        hint = QLabel(self.tr("Changes apply immediately. Icons appear when battery levels are available. "
+                             "On Windows, check the hidden icons (^) menu and drag the icons onto the taskbar."))
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+        layout.addStretch()
+        self.enabled.toggled.connect(self.on_enabled)
+        self.transparent.toggled.connect(self.on_transparent)
+        self.text_button.clicked.connect(self.on_text_color)
+        self.background_button.clicked.connect(self.on_background_color)
+        self.component.currentIndexChanged.connect(self.refresh_preview)
+        self.font_scale.valueChanged.connect(self.on_font_scale)
+        self.refresh_preview()
+
+    def setting_key(self, name):
+        return f"tray_battery_{self.component.currentData()}_{name}"
+
+    def color(self, key, fallback):
+        value = self.config.get("ui", key, fallback)
+        return value if isinstance(value, str) and QColor(value).isValid() else fallback
+
+    def refresh_preview(self, *_):
+        text, background, transparent, scale = battery_style(self.config, self.component.currentData())
+        self.text_button.setText(text)
+        self.background_button.setText(background)
+        with blocked_signals(self.transparent):
+            self.transparent.setChecked(bool(transparent))
+        with blocked_signals(self.font_scale):
+            self.font_scale.setValue(scale)
+        self.background_button.setEnabled(not transparent)
+        for icon, key, level in self.previews:
+            text, background, transparent, scale = battery_style(self.config, key)
+            icon.setPixmap(percentage_icon(
+                level, "light", text, None if transparent else background, scale
+            ).pixmap(32, 32))
+
+    async def save(self, key, value):
+        self.config.set("ui", key, value)
+        self.config.save()
+        self.refresh_preview()
+        await self.ofb.send_message(OfbEventKind.QT_SETTINGS_CHANGED)
+
+    @asyncSlot(bool)
+    async def on_enabled(self, value):
+        await self.save("tray_battery_percentages", value)
+
+    @asyncSlot(bool)
+    async def on_transparent(self, value):
+        await self.save(self.setting_key("transparent"), value)
+
+    @asyncSlot(int)
+    async def on_font_scale(self, value):
+        await self.save(self.setting_key("font_scale"), value)
+
+    async def choose_color(self, key, fallback):
+        dialog = QColorDialog(QColor(self.color(key, fallback)), self)
+        dialog.setWindowModality(Qt.WindowModality.WindowModal)
+        try:
+            if await run_dialog_async(dialog):
+                color = dialog.selectedColor()
+                if color.isValid():
+                    await self.save(key, color.name())
+        finally:
+            dialog.hide()
+            dialog.deleteLater()
+
+    @asyncSlot()
+    async def on_text_color(self):
+        await self.choose_color(self.setting_key("text_color"), self.text_button.text())
+
+    @asyncSlot()
+    async def on_background_color(self):
+        await self.choose_color(self.setting_key("background_color"), self.background_button.text())

--- a/openfreebuds_qt/app/module/tray_battery.py
+++ b/openfreebuds_qt/app/module/tray_battery.py
@@ -37,6 +37,10 @@ class OfbQtTrayBatteryModule(OfbQtCommonModule):
         self.font_scale.setSuffix("%")
         self.font_scale.setSingleStep(5)
         form.addRow(self.tr("Text size (100% = largest that fits)"), self.font_scale)
+        self.font_weight = QComboBox()
+        self.font_weight.addItem(self.tr("Normal"), False)
+        self.font_weight.addItem(self.tr("Bold"), True)
+        form.addRow(self.tr("Font weight"), self.font_weight)
         layout.addLayout(form)
         self.transparent = QCheckBox(self.tr("Transparent background"))
         layout.addWidget(self.transparent)
@@ -66,6 +70,7 @@ class OfbQtTrayBatteryModule(OfbQtCommonModule):
         self.background_button.clicked.connect(self.on_background_color)
         self.component.currentIndexChanged.connect(self.refresh_preview)
         self.font_scale.valueChanged.connect(self.on_font_scale)
+        self.font_weight.currentIndexChanged.connect(self.on_font_weight)
         self.refresh_preview()
 
     def setting_key(self, name):
@@ -76,18 +81,20 @@ class OfbQtTrayBatteryModule(OfbQtCommonModule):
         return value if isinstance(value, str) and QColor(value).isValid() else fallback
 
     def refresh_preview(self, *_):
-        text, background, transparent, scale = battery_style(self.config, self.component.currentData())
+        text, background, transparent, scale, bold = battery_style(self.config, self.component.currentData())
         self.text_button.setText(text)
         self.background_button.setText(background)
         with blocked_signals(self.transparent):
             self.transparent.setChecked(bool(transparent))
         with blocked_signals(self.font_scale):
             self.font_scale.setValue(scale)
+        with blocked_signals(self.font_weight):
+            self.font_weight.setCurrentIndex(self.font_weight.findData(bold))
         self.background_button.setEnabled(not transparent)
         for icon, key, level in self.previews:
-            text, background, transparent, scale = battery_style(self.config, key)
+            text, background, transparent, scale, bold = battery_style(self.config, key)
             icon.setPixmap(percentage_icon(
-                level, "light", text, None if transparent else background, scale
+                level, "light", text, None if transparent else background, scale, bold
             ).pixmap(32, 32))
 
     async def save(self, key, value):
@@ -107,6 +114,10 @@ class OfbQtTrayBatteryModule(OfbQtCommonModule):
     @asyncSlot(int)
     async def on_font_scale(self, value):
         await self.save(self.setting_key("font_scale"), value)
+
+    @asyncSlot(int)
+    async def on_font_weight(self, _index):
+        await self.save(self.setting_key("bold"), self.font_weight.currentData())
 
     async def choose_color(self, key, fallback):
         dialog = QColorDialog(QColor(self.color(key, fallback)), self)

--- a/openfreebuds_qt/assets/i18n/tr_TR.ts
+++ b/openfreebuds_qt/assets/i18n/tr_TR.ts
@@ -1224,6 +1224,9 @@
     </message>
 </context><context>
     <name>OfbQtTrayBatteryModule</name>
+    <message><source>Font weight</source><translation>Yazı kalınlığı</translation></message>
+    <message><source>Normal</source><translation>Normal</translation></message>
+    <message><source>Bold</source><translation>Kalın</translation></message>
     <message>
         <source>Show battery percentages in the system tray</source>
         <translation>Pil yüzdelerini sistem tepsisinde göster</translation>

--- a/openfreebuds_qt/assets/i18n/tr_TR.ts
+++ b/openfreebuds_qt/assets/i18n/tr_TR.ts
@@ -795,6 +795,11 @@
         <source>Exit OpenFreebuds</source>
         <translation>OpenFreebuds'tan çıkış yap</translation>
     </message>
+
+    <message>
+        <source>Tray battery</source>
+        <translation>Tray pil göstergeleri</translation>
+    </message>
 </context><context>
     <name>OfbQtManualConnectDialog</name>
     <message>
@@ -1157,6 +1162,19 @@
         <source>OpenFreebuds: Connecting to device…</source>
         <translation>OpenFreebuds: Cihaza bağlanıyor…</translation>
     </message>
+
+    <message>
+        <source>Left earbud</source>
+        <translation>Sol kulaklık</translation>
+    </message>
+    <message>
+        <source>Right earbud</source>
+        <translation>Sağ kulaklık</translation>
+    </message>
+    <message>
+        <source>Charging case</source>
+        <translation>Şarj kutusu</translation>
+    </message>
 </context><context>
     <name>ShortcutName</name>
     <message>
@@ -1204,4 +1222,53 @@
         <source>Enable low-latency mode</source>
         <translation>Düşük gecikme modunu etkinleştirin</translation>
     </message>
-</context></TS>
+</context><context>
+    <name>OfbQtTrayBatteryModule</name>
+    <message>
+        <source>Show battery percentages in the system tray</source>
+        <translation>Pil yüzdelerini sistem tepsisinde göster</translation>
+    </message>
+    <message>
+        <source>Text color</source>
+        <translation>Yazı rengi</translation>
+    </message>
+    <message>
+        <source>Background color</source>
+        <translation>Arka plan rengi</translation>
+    </message>
+    <message>
+        <source>Transparent background</source>
+        <translation>Şeffaf arka plan</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>Önizleme</translation>
+    </message>
+    <message>
+        <source>Left earbud</source>
+        <translation>Sol kulaklık</translation>
+    </message>
+    <message>
+        <source>Right earbud</source>
+        <translation>Sağ kulaklık</translation>
+    </message>
+    <message>
+        <source>Charging case</source>
+        <translation>Şarj kutusu</translation>
+    </message>
+    <message>
+        <source>Changes apply immediately. Icons appear when battery levels are available. On Windows, check the hidden icons (^) menu and drag the icons onto the taskbar.</source>
+        <translation>Değişiklikler hemen uygulanır. Pil bilgisi alındığında simgeler görünür. Windows’ta gizli simgeler (^) menüsüne bakın ve simgeleri görev çubuğuna sürükleyin.</translation>
+    </message>
+
+    <message>
+        <source>Customize indicator</source>
+        <translation>Düzenlenecek gösterge</translation>
+    </message>
+
+    <message>
+        <source>Text size (100% = largest that fits)</source>
+        <translation>Yazı boyutu (%100 = simgeye sığan en büyük boyut)</translation>
+    </message>
+</context>
+</TS>

--- a/openfreebuds_qt/tray/battery.py
+++ b/openfreebuds_qt/tray/battery.py
@@ -32,10 +32,12 @@ def battery_style(config, key):
     transparent = transparent if isinstance(transparent, bool) else False
     scale = value("font_scale", 100)
     scale = max(50, min(100, scale)) if type(scale) is int else 100
-    return text, background, transparent, scale
+    bold = value("bold", True)
+    bold = bold if isinstance(bold, bool) else True
+    return text, background, transparent, scale, bold
 
 
-def percentage_icon(level: int, theme: str, text_color=None, background_color=None, font_scale=100) -> QIcon:
+def percentage_icon(level: int, theme: str, text_color=None, background_color=None, font_scale=100, bold=True) -> QIcon:
     """Render numeric battery levels at native tray sizes for each DPI."""
     icon = QIcon()
     for size in (16, 20, 24, 32, 48, 64):
@@ -49,7 +51,7 @@ def percentage_icon(level: int, theme: str, text_color=None, background_color=No
             "#161616" if theme == "dark" else "#ffffff"
         ))
         font = QFont("Segoe UI")
-        font.setBold(True)
+        font.setBold(bold)
         text = str(level)
         for pixels in range(size, 3, -1):
             font.setPixelSize(pixels)

--- a/openfreebuds_qt/tray/battery.py
+++ b/openfreebuds_qt/tray/battery.py
@@ -1,0 +1,64 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QFont, QFontMetrics, QIcon, QPainter, QPixmap
+
+
+def battery_levels(battery):
+    """Return only reported, valid levels; never invent a zero for missing data."""
+    if not isinstance(battery, dict):
+        return {}
+    keys = ("left", "right", "case")
+    levels = {}
+    for key in keys:
+        value = battery.get(key)
+        if isinstance(value, str) and value.isascii() and value.isdigit():
+            value = int(value)
+        if type(value) is int and 0 <= value <= 100:
+            levels[key] = value
+    return levels
+
+
+def battery_style(config, key):
+    """Per-component overrides inherit existing shared settings."""
+    def value(name, default):
+        shared = config.get("ui", f"tray_battery_{name}", default)
+        return config.get("ui", f"tray_battery_{key}_{name}", shared)
+    text = value("text_color", "#ffffff")
+    background = value("background_color", "#202020")
+    if not isinstance(text, str) or not QColor(text).isValid():
+        text = "#ffffff"
+    if not isinstance(background, str) or not QColor(background).isValid():
+        background = "#202020"
+    transparent = value("transparent", False)
+    transparent = transparent if isinstance(transparent, bool) else False
+    scale = value("font_scale", 100)
+    scale = max(50, min(100, scale)) if type(scale) is int else 100
+    return text, background, transparent, scale
+
+
+def percentage_icon(level: int, theme: str, text_color=None, background_color=None, font_scale=100) -> QIcon:
+    """Render numeric battery levels at native tray sizes for each DPI."""
+    icon = QIcon()
+    for size in (16, 20, 24, 32, 48, 64):
+        pixmap = QPixmap(size, size)
+        background = QColor(background_color) if isinstance(background_color, str) else QColor()
+        pixmap.fill(background if background.isValid() else Qt.GlobalColor.transparent)
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.RenderHint.TextAntialiasing)
+        foreground = QColor(text_color) if isinstance(text_color, str) else QColor()
+        painter.setPen(foreground if foreground.isValid() else QColor(
+            "#161616" if theme == "dark" else "#ffffff"
+        ))
+        font = QFont("Segoe UI")
+        font.setBold(True)
+        text = str(level)
+        for pixels in range(size, 3, -1):
+            font.setPixelSize(pixels)
+            metrics = QFontMetrics(font)
+            if metrics.horizontalAdvance(text) <= size and metrics.height() <= size:
+                break
+        font.setPixelSize(max(4, round(font.pixelSize() * font_scale / 100)))
+        painter.setFont(font)
+        painter.drawText(pixmap.rect(), Qt.AlignmentFlag.AlignCenter, text)
+        painter.end()
+        icon.addPixmap(pixmap)
+    return icon

--- a/openfreebuds_qt/tray/main.py
+++ b/openfreebuds_qt/tray/main.py
@@ -13,6 +13,7 @@ from openfreebuds_qt.config.main import OfbQtConfigParser
 from openfreebuds_qt.generic import IOfbQtApplication
 from openfreebuds_qt.generic import IOfbTrayIcon
 from openfreebuds_qt.tray.menu import OfbQtTrayMenu
+from openfreebuds_qt.tray.battery import battery_levels, battery_style, percentage_icon
 from openfreebuds_qt.utils import OfbCoreEvent, qt_error_handler, create_tray_icon
 
 try:
@@ -52,6 +53,8 @@ class OfbTrayIcon(IOfbTrayIcon):
 
         self.menu = OfbQtTrayMenu(self, self.ctx, self.ofb)
         self.setContextMenu(self.menu)
+        self._battery_icons = {}
+        self._battery_icon_values = {}
 
     @asyncSlot(QSystemTrayIcon.ActivationReason)
     async def _on_click(self, reason):
@@ -77,6 +80,8 @@ class OfbTrayIcon(IOfbTrayIcon):
         """
         Will stop UI update loop
         """
+        for icon in self._battery_icons.values():
+            icon.hide()
         if self.ui_update_task is not None:
             self.ui_update_task.cancel()
             await self.ui_update_task
@@ -96,6 +101,7 @@ class OfbTrayIcon(IOfbTrayIcon):
                                 await self.ofb.get_property("anc", "mode", "normal"))
         pixmap = QIcon(ImageQt.toqpixmap(icon))
         self.setIcon(pixmap)
+        await self._update_battery_icons(state)
 
         # Update menu and tooltip
         if state == IOpenFreebuds.STATE_CONNECTED:
@@ -116,6 +122,45 @@ class OfbTrayIcon(IOfbTrayIcon):
             self._reset_battery_summary_overlay()
 
         await self.menu.on_core_event(event, state)
+
+    async def _update_battery_icons(self, state):
+        levels = {}
+        if state == IOpenFreebuds.STATE_CONNECTED and self.config.get(
+            "ui", "tray_battery_percentages", False
+        ):
+            levels = battery_levels(await self.ofb.get_property("battery"))
+        labels = {
+            "left": self.tr("Left earbud"),
+            "right": self.tr("Right earbud"),
+            "case": self.tr("Charging case"),
+        }
+        theme = self.config.get_tray_icon_theme() if levels else None
+        device_name, _ = await self.ofb.get_device_tags() if levels else ("", "")
+        for key, icon in self._battery_icons.items():
+            if key not in levels:
+                icon.hide()
+        for key, level in levels.items():
+            text_color, background_color, transparent, font_scale = battery_style(self.config, key)
+            if transparent:
+                background_color = None
+            if key not in self._battery_icons:
+                icon = QSystemTrayIcon(self)
+                icon.setContextMenu(self.menu)
+                icon.activated.connect(self._on_battery_click)
+                self._battery_icons[key] = icon
+            icon = self._battery_icons[key]
+            appearance = (level, theme, text_color, background_color, font_scale)
+            if self._battery_icon_values.get(key) != appearance:
+                icon.setIcon(percentage_icon(*appearance))
+                self._battery_icon_values[key] = appearance
+            icon.setToolTip(f"{device_name} — {labels[key]}: {level}%")
+            icon.show()
+
+    def _on_battery_click(self, reason):
+        if reason == self.ActivationReason.Trigger:
+            self.ctx.main_window.show()
+            self.ctx.main_window.raise_()
+            self.ctx.main_window.activateWindow()
 
     async def _get_tooltip_text(self, event: OfbCoreEvent):
         """
@@ -265,6 +310,7 @@ class OfbTrayIcon(IOfbTrayIcon):
 
                     if event.kind_in([
                         OfbEventKind.STATE_CHANGED,
+                        OfbEventKind.DEVICE_CHANGED,
                         OfbEventKind.QT_SETTINGS_CHANGED,
                         OfbEventKind.PROPERTY_CHANGED,
                     ]):

--- a/openfreebuds_qt/tray/main.py
+++ b/openfreebuds_qt/tray/main.py
@@ -140,7 +140,7 @@ class OfbTrayIcon(IOfbTrayIcon):
             if key not in levels:
                 icon.hide()
         for key, level in levels.items():
-            text_color, background_color, transparent, font_scale = battery_style(self.config, key)
+            text_color, background_color, transparent, font_scale, bold = battery_style(self.config, key)
             if transparent:
                 background_color = None
             if key not in self._battery_icons:
@@ -149,7 +149,7 @@ class OfbTrayIcon(IOfbTrayIcon):
                 icon.activated.connect(self._on_battery_click)
                 self._battery_icons[key] = icon
             icon = self._battery_icons[key]
-            appearance = (level, theme, text_color, background_color, font_scale)
+            appearance = (level, theme, text_color, background_color, font_scale, bold)
             if self._battery_icon_values.get(key) != appearance:
                 icon.setIcon(percentage_icon(*appearance))
                 self._battery_icon_values[key] = appearance

--- a/openfreebuds_qt/tray/test_battery.py
+++ b/openfreebuds_qt/tray/test_battery.py
@@ -1,0 +1,154 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication, QSystemTrayIcon
+
+from openfreebuds import IOpenFreebuds
+from openfreebuds_qt.tray.battery import battery_levels, battery_style
+from openfreebuds_qt.tray.main import OfbTrayIcon
+
+
+@pytest.mark.parametrize("data, expected", [
+    ({"left": 0, "right": "100", "case": 85, "global": 0},
+     {"left": 0, "right": 100, "case": 85}),
+    ({"left": True, "right": -1, "case": 101}, {}),
+    ({"global": "50"}, {}),
+    ({"left": "--", "global": 50}, {}),
+    (None, {}),
+])
+def test_reported_levels(data, expected):
+    assert battery_levels(data) == expected
+
+
+def test_invalid_saved_style_falls_back():
+    config = SimpleNamespace(get=lambda *args: {"malformed": True})
+    assert battery_style(config, "left") == ("#ffffff", "#202020", False, 100)
+
+
+@pytest.mark.asyncio
+async def test_tray_percentages_lifecycle(monkeypatch):
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    tray = QSystemTrayIcon()
+    enabled = True
+    tray.config = SimpleNamespace(
+        get=lambda section, key, default=None: enabled if key == "tray_battery_percentages" else default,
+        get_tray_icon_theme=lambda: "light"
+    )
+    tray.ofb = SimpleNamespace(
+        get_property=AsyncMock(return_value={"left": 50, "right": 65, "case": 85}),
+        get_device_tags=AsyncMock(return_value=("Test", "address")),
+    )
+    tray.menu = None
+    tray._battery_icons = {}
+    tray._battery_icon_values = {}
+    tray._on_battery_click = lambda reason: None
+    connected = IOpenFreebuds.STATE_CONNECTED
+    try:
+        await OfbTrayIcon._update_battery_icons(tray, connected)
+        assert all(icon.isVisible() for icon in tray._battery_icons.values())
+        assert "50%" in tray._battery_icons["left"].toolTip()
+        tray.ofb.get_property.return_value = {"left": 100}
+        await OfbTrayIcon._update_battery_icons(tray, connected)
+        assert "100%" in tray._battery_icons["left"].toolTip()
+        assert not tray._battery_icons["case"].isVisible()
+        enabled = False
+        await OfbTrayIcon._update_battery_icons(tray, connected)
+        assert not any(icon.isVisible() for icon in tray._battery_icons.values())
+        enabled = True
+        await OfbTrayIcon._update_battery_icons(tray, connected)
+        await OfbTrayIcon._update_battery_icons(tray, IOpenFreebuds.STATE_WAIT)
+        assert not any(icon.isVisible() for icon in tray._battery_icons.values())
+    finally:
+        for icon in tray._battery_icons.values():
+            icon.hide()
+        tray.deleteLater()
+        app.processEvents()
+
+
+@pytest.mark.asyncio
+async def test_appearance_settings_save_and_render(monkeypatch, tmp_path):
+    from PyQt6.QtGui import QColor
+    from openfreebuds_qt.tray.battery import percentage_icon
+    from openfreebuds_qt.app.module.tray_battery import OfbQtTrayBatteryModule
+    from openfreebuds_qt.config import OfbQtConfigParser
+    import openfreebuds_qt.config.main as config_module
+
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "settings.json")
+    monkeypatch.setattr(OfbQtConfigParser, "instance", None)
+    ofb = SimpleNamespace(send_message=AsyncMock())
+    page = OfbQtTrayBatteryModule(None, SimpleNamespace(ofb=ofb))
+    assert [page.component.itemData(i) for i in range(page.component.count())] == ["left", "right", "case"]
+    await page.save("tray_battery_text_color", "#ff0000")
+    await page.save("tray_battery_background_color", "#123456")
+    assert OfbQtConfigParser().get("ui", "tray_battery_background_color") == "#123456"
+    assert page.background_button.text() == "#123456"
+    ofb.send_message.assert_awaited()
+    image = percentage_icon(50, "light", "#ff0000", "#123456").pixmap(32, 32).toImage()
+    assert image.pixelColor(0, 0) == QColor("#123456")
+    assert any(image.pixelColor(x, y) == QColor("#ff0000") for x in range(32) for y in range(32))
+    transparent = percentage_icon(100, "light", "#ff0000", None).pixmap(32, 32).toImage()
+    assert transparent.pixelColor(0, 0).alpha() == 0
+    from openfreebuds_qt.tray.battery import battery_style
+    await page.save("tray_battery_left_text_color", "#00ff00")
+    await page.save("tray_battery_left_font_scale", 60)
+    await page.save("tray_battery_right_background_color", "#0000ff")
+    assert battery_style(page.config, "left") == ("#00ff00", "#123456", False, 60)
+    assert battery_style(page.config, "right") == ("#ff0000", "#0000ff", False, 100)
+    page.component.setCurrentIndex(1)
+    assert page.text_button.text() == "#ff0000"
+    assert page.background_button.text() == "#0000ff"
+    assert page.font_scale.value() == 100
+    page.component.setCurrentIndex(0)
+    assert page.font_scale.value() == 60
+    reloaded = OfbQtConfigParser()
+    assert battery_style(reloaded, "left")[3] == 60
+    small = percentage_icon(50, "light", "#ff0000", None, 50).pixmap(32, 32).toImage()
+    large = percentage_icon(50, "light", "#ff0000", None, 100).pixmap(32, 32).toImage()
+    def painted_pixels(image):
+        return sum(image.pixelColor(x, y).alpha() > 0 for x in range(32) for y in range(32))
+    assert painted_pixels(small) < painted_pixels(large)
+    page.deleteLater()
+    app.processEvents()
+
+
+@pytest.mark.asyncio
+async def test_color_dialog_accept_and_cancel(monkeypatch, tmp_path):
+    from PyQt6.QtGui import QColor
+    from PyQt6.QtWidgets import QColorDialog
+    from openfreebuds_qt.app.module.tray_battery import OfbQtTrayBatteryModule
+    from openfreebuds_qt.config import OfbQtConfigParser
+    import openfreebuds_qt.config.main as config_module
+
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "settings.json")
+    monkeypatch.setattr(OfbQtConfigParser, "instance", None)
+    ofb = SimpleNamespace(send_message=AsyncMock())
+    page = OfbQtTrayBatteryModule(None, SimpleNamespace(ofb=ofb))
+    key = "tray_battery_left_text_color"
+    task = asyncio.create_task(page.choose_color(key, "#ffffff"))
+    await asyncio.sleep(0)
+    dialog = next(dialog for dialog in page.findChildren(QColorDialog) if dialog.isVisible())
+    dialog.setCurrentColor(QColor("#123456"))
+    dialog.accept()
+    await asyncio.wait_for(task, 2)
+    assert page.config.get("ui", key) == "#123456"
+    ofb.send_message.assert_awaited_once()
+
+    task = asyncio.create_task(page.choose_color(key, "#ffffff"))
+    await asyncio.sleep(0)
+    dialog = next(dialog for dialog in page.findChildren(QColorDialog) if dialog.isVisible())
+    dialog.setCurrentColor(QColor("#abcdef"))
+    dialog.reject()
+    await asyncio.wait_for(task, 2)
+    assert page.config.get("ui", key) == "#123456"
+    ofb.send_message.assert_awaited_once()
+    page.deleteLater()
+    app.processEvents()

--- a/openfreebuds_qt/tray/test_battery.py
+++ b/openfreebuds_qt/tray/test_battery.py
@@ -26,7 +26,7 @@ def test_reported_levels(data, expected):
 
 def test_invalid_saved_style_falls_back():
     config = SimpleNamespace(get=lambda *args: {"malformed": True})
-    assert battery_style(config, "left") == ("#ffffff", "#202020", False, 100)
+    assert battery_style(config, "left") == ("#ffffff", "#202020", False, 100, True)
 
 
 @pytest.mark.asyncio
@@ -99,8 +99,8 @@ async def test_appearance_settings_save_and_render(monkeypatch, tmp_path):
     await page.save("tray_battery_left_text_color", "#00ff00")
     await page.save("tray_battery_left_font_scale", 60)
     await page.save("tray_battery_right_background_color", "#0000ff")
-    assert battery_style(page.config, "left") == ("#00ff00", "#123456", False, 60)
-    assert battery_style(page.config, "right") == ("#ff0000", "#0000ff", False, 100)
+    assert battery_style(page.config, "left") == ("#00ff00", "#123456", False, 60, True)
+    assert battery_style(page.config, "right") == ("#ff0000", "#0000ff", False, 100, True)
     page.component.setCurrentIndex(1)
     assert page.text_button.text() == "#ff0000"
     assert page.background_button.text() == "#0000ff"
@@ -109,6 +109,11 @@ async def test_appearance_settings_save_and_render(monkeypatch, tmp_path):
     assert page.font_scale.value() == 60
     reloaded = OfbQtConfigParser()
     assert battery_style(reloaded, "left")[3] == 60
+    await page.save("tray_battery_left_bold", False)
+    assert page.font_weight.currentData() is False
+    page.component.setCurrentIndex(1)
+    assert page.font_weight.currentData() is True
+    assert battery_style(OfbQtConfigParser(), "left")[4] is False
     small = percentage_icon(50, "light", "#ff0000", None, 50).pixmap(32, 32).toImage()
     large = percentage_icon(50, "light", "#ff0000", None, 100).pixmap(32, 32).toImage()
     def painted_pixels(image):


### PR DESCRIPTION
Users currently need to open the tray menu or settings to read individual earbud and case battery levels. This adds optional independent numeric tray indicators alongside the existing tray icon.

## Changes

- Dedicated Application → Tray battery settings page; indicators are disabled by default.
- Separate left earbud, right earbud, and charging case icons, displaying numbers without a percent sign.
- Per-indicator text/background colors, transparency, Normal/Bold font weight (Bold by default), and text scale (50–100% of the largest size that fits), with sample previews.
- Immediate updates for battery and appearance changes; indicators hide when disconnected, disabled, or their reported level is missing/invalid.
- Tooltips identify each component; left-click opens settings and right-click opens the existing tray menu.
- Color selection uses the existing asynchronous dialog helper; cancellation preserves settings.
- Turkish translations, README documentation, and regression tests.

The application creates icons in left/right/case order, but Windows controls their displayed order and overflow placement. Devices reporting only an aggregate battery level receive no additional indicator.

## Validation

- 19 pytest tests passed on Windows / Python 3.12.14, covering lifecycle, independent persisted styles including font weight, rendering, invalid configuration fallback, and color-dialog acceptance/cancellation.
- Qt translations and UI generation succeeded; wheel and sdist built successfully.
- Manually checked on the Windows desktop with the built-in virtual FreeBuds 5i profile.
- A local Windows x64 NSIS installer was built with the font-weight option; the bundled executable passed its startup/import check. Packaging required excluding unrelated build-environment DLLs and bundling the Qt runtime DLLs. These local packaging adjustments are not part of this PR.
- git diff --check passed.

Not yet verified: Linux desktop tray behavior, physical Bluetooth devices, end-to-end installer installation/uninstallation, portable EXE packaging, and GitHub CI.